### PR TITLE
Fix for issue #2

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1078,8 +1078,10 @@ final class Cachify {
 
 	private static function _cache_hash($url = '')
 	{
+		if(is_ssl()) $prefix='443-';else $prefix='80-';
+		
 		return md5(
-			empty($url) ? ( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) : ( parse_url($url, PHP_URL_HOST) . parse_url($url, PHP_URL_PATH) )
+			empty($url) ? ( $prefix . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) : ( $prefix . parse_url($url, PHP_URL_HOST) . parse_url($url, PHP_URL_PATH) )
 		) . '.cachify';
 	}
 

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -336,12 +336,15 @@ final class Cachify_HDD {
 
 	private static function _file_path($path = NULL)
 	{
+		if(is_ssl()) $prefix='443-';else $prefix='80-';
+		
 		$path = sprintf(
-			'%s%s%s%s',
+			'%s%s%s%s%s',
 			CACHIFY_CACHE_DIR,
 			DIRECTORY_SEPARATOR,
+			$prefix,
 			parse_url(
-				'http://' .strtolower($_SERVER['HTTP_HOST']),
+				'http://' . strtolower($_SERVER['HTTP_HOST']),
 				PHP_URL_HOST
 			),
 			parse_url(


### PR DESCRIPTION
Fix for issue #2 as supposed in https://wordpress.org/support/topic/separate-caches-for-http-and-https but using is_ssl() instead of server variables.