### PR TITLE
Add URL scheme to hashkey.

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1079,7 +1079,8 @@ final class Cachify {
 	private static function _cache_hash($url = '')
 	{
 		return md5(
-			empty($url) ? ( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) : ( parse_url($url, PHP_URL_HOST) . parse_url($url, PHP_URL_PATH) )
+			empty($url) ? ( ( isset($_SERVER['HTTPS']) ? 'https' : 'http' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] )
+			            : ( parse_url($url, PHP_URL_SCHEME) . parse_url($url, PHP_URL_HOST) . parse_url($url, PHP_URL_PATH) )
 		) . '.cachify';
 	}
 


### PR DESCRIPTION
When Wordpress instance is accessed as http://site, Cachify stores page contents containing http:// links.

When somebody accesses https://site, then already generated page is returned, and all http:// links are blocked by web browser as cross-origins.

So cache keys should include URL scheme (http or https).