### PR TITLE
Prevent the inline css for the admin bar icon to overwrite other items

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -705,7 +705,7 @@ final class Cachify {
 		}
 
 		/* Display the admin icon anytime */
-		echo '<style>#wp-admin-bar-cachify{display:list-item !important} .ab-icon{margin:0 !important} .ab-icon:before{content:"\f182";top:2px;margin:0}</style>';
+		echo '<style>#wp-admin-bar-cachify{display:list-item !important} #wp-admin-bar-cachify .ab-icon{margin:0 !important} #wp-admin-bar-cachify .ab-icon:before{content:"\f182";top:2px;margin:0}</style>';
 
 		/* Hinzufügen */
 		$wp_admin_bar->add_menu(


### PR DESCRIPTION
The current inline CSS for the admin bar trash icon overwrites other admin bar items, especially if these items are using an `.ab-icon` with dashicons.