### PR TITLE
Comment translation

### DIFF
--- a/cachify.php
+++ b/cachify.php
@@ -35,7 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 defined('ABSPATH') OR exit;
 
 
-/* Konstanten */
+/* Constants */
 define('CACHIFY_FILE', __FILE__);
 define('CACHIFY_DIR', dirname(__FILE__));
 define('CACHIFY_BASE', plugin_basename(__FILE__));
@@ -76,7 +76,7 @@ register_uninstall_hook(
 /* Autoload Init */
 spl_autoload_register('cachify_autoload');
 
-/* Autoload Funktion */
+/* Autoload function */
 function cachify_autoload($class) {
 	if ( in_array($class, array('Cachify', 'Cachify_APC', 'Cachify_DB', 'Cachify_HDD', 'Cachify_MEMCACHED')) ) {
 		require_once(

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -13,7 +13,7 @@ final class Cachify {
 
 
 	/**
-	* Plugin-Optionen
+	* Plugin options
 	*
 	* @since  2.0
 	* @var    array
@@ -23,7 +23,7 @@ final class Cachify {
 
 
 	/**
-	* Cache-Methode
+	* Caching method
 	*
 	* @since  2.0
 	* @var    object
@@ -58,7 +58,7 @@ final class Cachify {
 
 
 	/**
-	* Pseudo-Konstruktor der Klasse
+	* Pseudo-Constructor
 	*
 	* @since   2.0.5
 	* @change  2.0.5
@@ -71,7 +71,7 @@ final class Cachify {
 
 
 	/**
-	* Konstruktor der Klasse
+	* Constructor
 	*
 	* @since   1.0.0
 	* @change  2.2.2
@@ -304,13 +304,13 @@ final class Cachify {
 			/* Blog-IDs */
 			$ids = self::_get_blog_ids();
 
-			/* Loopen */
+			/* Loop over blogs */
 			foreach ($ids as $id) {
 				switch_to_blog($id);
 				self::_install_backend();
 			}
 
-			/* Wechsel zurück */
+			/* Switch back */
 			restore_current_blog();
 
 		} else {
@@ -320,32 +320,34 @@ final class Cachify {
 
 
 	/**
-	* Plugin-Installation bei neuen MU-Blogs
-	*
-	* @since   1.0
-	* @change  1.0
-	*/
+	 * Plugin-Installation on new MU-Blogs
+	 *
+	 * @since   1.0
+	 * @change  1.0
+	 *
+	 * @param integer $id  Blog ID
+	 */
 
 	public static function install_later($id)
 	{
-		/* Kein Netzwerk-Plugin */
+		/* No network-plugin */
 		if ( ! is_plugin_active_for_network(CACHIFY_BASE) ) {
 			return;
 		}
 
-		/* Wechsel */
+		/* Switch to blog */
 		switch_to_blog($id);
 
-		/* Installieren */
+		/* Install */
 		self::_install_backend();
 
-		/* Wechsel zurück */
+		/* Switch back */
 		restore_current_blog();
 	}
 
 
 	/**
-	* Eigentliche Installation der Optionen
+	* Actual installation of the options
 	*
 	* @since   1.0
 	* @change  2.0
@@ -364,7 +366,7 @@ final class Cachify {
 
 
 	/**
-	* Deinstallation des Plugins pro MU-Blog
+	* Uninstalling of the plugin per MU-Blog
 	*
 	* @since   1.0
 	* @change  2.1.0
@@ -383,13 +385,13 @@ final class Cachify {
 			/* Blog-IDs */
 			$ids = self::_get_blog_ids();
 
-			/* Loopen */
+			/* Loop */
 			foreach ($ids as $id) {
 				switch_to_blog($id);
 				self::_uninstall_backend();
 			}
 
-			/* Wechsel zurück */
+			/* Switch back */
 			switch_to_blog($old);
 		} else {
 			self::_uninstall_backend();
@@ -398,32 +400,34 @@ final class Cachify {
 
 
 	/**
-	* Deinstallation des Plugins bei MU & Network
-	*
-	* @since   1.0
-	* @change  1.0
-	*/
+	 * Uninstalling of the plugin für MU and Network
+	 *
+	 * @since   1.0
+	 * @change  1.0
+	 *
+	 * @param integer $id  Blog ID
+	 */
 
 	public static function uninstall_later($id)
 	{
-		/* Kein Netzwerk-Plugin */
+		/* No network plugin */
 		if ( ! is_plugin_active_for_network(CACHIFY_BASE) ) {
 			return;
 		}
 
-		/* Wechsel */
+		/* Switch to blog */
 		switch_to_blog($id);
 
-		/* Installieren */
+		/* Install */
 		self::_uninstall_backend();
 
-		/* Wechsel zurück */
+		/* Switch back */
 		restore_current_blog();
 	}
 
 
 	/**
-	* Eigentliche Deinstallation des Plugins
+	* Actual uninstalling of the plugin
 	*
 	* @since   1.0
 	* @change  1.0
@@ -434,13 +438,13 @@ final class Cachify {
 		/* Option */
 		delete_option('cachify');
 
-		/* Cache leeren */
+		/* Flush cache */
 		self::flush_total_cache(true);
 	}
 
 
 	/**
-	* Rückgabe der IDs installierter Blogs
+	* Get IDs of installed blogs
 	*
 	* @since   1.0
 	* @change  1.0
@@ -458,7 +462,7 @@ final class Cachify {
 
 
 	/**
-	* Eigenschaften des Objekts
+	* Set default options
 	*
 	* @since   2.0
 	* @change  2.0.7
@@ -466,7 +470,7 @@ final class Cachify {
 
 	private static function _set_default_vars()
 	{
-		/* Optionen */
+		/* Options */
 		self::$options = self::_get_options();
 
 		/* APC */
@@ -489,12 +493,12 @@ final class Cachify {
 
 
 	/**
-	* Rückgabe der Optionen
+	* Get options
 	*
 	* @since   2.0
 	* @change  2.1.2
 	*
-	* @return  array  $diff  Array mit Werten
+	* @return  array  Array of option values
 	*/
 
 	private static function _get_options()
@@ -515,13 +519,13 @@ final class Cachify {
 
 
 	/**
-	* Hinzufügen der Action-Links
+	* Modify robots.txt
 	*
 	* @since   1.0
 	* @change  2.1.9
 	*
-	* @param   string  $data  Ursprungsinhalt der dynamischen robots.txt
-	* @return  string  $data  Modifizierter Inhalt der robots.txt
+	* @param   string  $data  Original content of dynamic robots.txt
+	* @return  string         Modified content of robots.txt
 	*/
 
 	public static function robots_txt($data)
@@ -531,10 +535,10 @@ final class Cachify {
 			return $data;
 		}
 
-		/* Pfad */
+		/* Path */
 		$path = parse_url(site_url(), PHP_URL_PATH);
 
-		/* Ausgabe */
+		/* Output */
 		$data .= sprintf(
 			'%2$sDisallow: %1$s/wp-content/cache/cachify/%2$s',
 			( empty($path) ? '' : $path ),
@@ -546,18 +550,18 @@ final class Cachify {
 
 
 	/**
-	* Hinzufügen der Action-Links
+	* Add the action links
 	*
 	* @since   1.0
 	* @change  1.0
 	*
-	* @param   array  $data  Bereits existente Links
-	* @return  array  $data  Erweitertes Array mit Links
+	* @param   array  $data  Initial array with action links
+	* @return  array         Merged array with action links
 	*/
 
 	public static function action_links($data)
 	{
-		/* Rechte? */
+		/* Permissions? */
 		if ( ! current_user_can('manage_options') ) {
 			return $data;
 		}
@@ -581,19 +585,19 @@ final class Cachify {
 
 
 	/**
-	* Meta-Links des Plugins
+	* Meta links of the plugin
 	*
 	* @since   0.5
 	* @change  2.0.5
 	*
-	* @param   array   $input  Bereits vorhandene Links
-	* @param   string  $page   Aktuelle Seite
-	* @return  array   $data   Modifizierte Links
+	* @param   array   $input  Initial array with meta links
+	* @param   string  $page   Current page
+	* @return  array           Merged array with meta links
 	*/
 
 	public static function row_meta($input, $page)
 	{
-		/* Rechte */
+		/* Permissions */
 		if ( $page != CACHIFY_BASE ) {
 			return $input;
 		}
@@ -608,13 +612,13 @@ final class Cachify {
 
 
 	/**
-	* Anzeige des Spam-Counters auf dem Dashboard
+	* Add cache properties to dashboard
 	*
 	* @since   2.0.0
 	* @change  2.2.2
 	*
 	* @param   array  $items  Initial array with dashboard items
-	* @return  array  $items  Merged array with dashboard items
+	* @return  array          Merged array with dashboard items
 	*/
 
 	public static function add_dashboard_count( $items = array() )
@@ -655,18 +659,18 @@ final class Cachify {
 
 
 	/**
-	* Rückgabe der Cache-Größe
+	* Get the cache size
 	*
 	* @since   2.0.6
 	* @change  2.0.6
 	*
-	* @param   integer  $size  Cache-Größe in Bytes
+	* @return  integer    Cache size in Bytes
 	*/
 
 	public static function get_cache_size()
 	{
 		if ( ! $size = get_transient('cachify_cache_size') ) {
-			/* Auslesen */
+			/* Read */
 			$size = (int) call_user_func(
 				array(
 					self::$method,
@@ -674,7 +678,7 @@ final class Cachify {
 				)
 			);
 
-			/* Speichern */
+			/* Save */
 			set_transient(
 			  'cachify_cache_size',
 			  $size,
@@ -687,19 +691,19 @@ final class Cachify {
 
 
 	/**
-	* Hinzufügen eines Admin-Bar-Menüs
+	* Add flush icon to admin bar menu
 	*
 	* @since   1.2
 	* @change  2.2.2
     *
     * @hook    mixed   cachify_user_can_flush_cache
 	*
-	* @param   object  Objekt mit Menü-Eigenschaften
+	* @param   object  $wp_admin_bar  Object of menu items
 	*/
 
 	public static function add_flush_icon($wp_admin_bar)
 	{
-		/* Aussteigen */
+		/* Quit */
 		if ( ! is_admin_bar_showing() OR ! apply_filters('cachify_user_can_flush_cache', current_user_can('manage_options')) ) {
 			return;
 		}
@@ -707,7 +711,7 @@ final class Cachify {
 		/* Display the admin icon anytime */
 		echo '<style>#wp-admin-bar-cachify{display:list-item !important} #wp-admin-bar-cachify .ab-icon{margin:0 !important} #wp-admin-bar-cachify .ab-icon:before{content:"\f182";top:2px;margin:0}</style>';
 
-		/* Hinzufügen */
+		/* Add menu item */
 		$wp_admin_bar->add_menu(
 			array(
 				'id' 	 => 'cachify',
@@ -721,14 +725,14 @@ final class Cachify {
 
 
 	/**
-	* Verarbeitung der Plugin-Meta-Aktionen
+	* Process plugin's meta actions
 	*
 	* @since   0.5
 	* @change  2.2.2
     *
     * @hook    mixed  cachify_user_can_flush_cache
 	*
-	* @param   array  $data  Metadaten der Plugins
+	* @param   array  $data  Metadata of the plugin
 	*/
 
 	public static function process_flush_request($data)
@@ -755,22 +759,22 @@ final class Cachify {
 
 		/* Multisite & Network */
 		if ( is_multisite() && is_plugin_active_for_network(CACHIFY_BASE) ) {
-			/* Alter Blog */
+			/* Old blog */
 			$old = $GLOBALS['wpdb']->blogid;
 
 			/* Blog-IDs */
 			$ids = self::_get_blog_ids();
 
-			/* Loopen */
+			/* Loop over blogs */
 			foreach ($ids as $id) {
 				switch_to_blog($id);
 				self::flush_total_cache();
 			}
 
-			/* Wechsel zurück */
+			/* Switch back to old blog */
 			switch_to_blog($old);
 
-			/* Notiz */
+			/* Notice */
 			if ( is_admin() ) {
 				add_action(
 					'network_admin_notices',
@@ -781,10 +785,10 @@ final class Cachify {
 				);
 			}
 		} else {
-			/* Leeren */
+			/* Flush cache */
 			self::flush_total_cache();
 
-			/* Notiz */
+			/* Notice */
 			if ( is_admin() ) {
 				add_action(
 					'admin_notices',
@@ -810,7 +814,7 @@ final class Cachify {
 
 
 	/**
-	* Hinweis nach erfolgreichem Cache-Leeren
+	* Notice after successful flushing of the cache
 	*
 	* @since   1.2
 	* @change  2.2.2
@@ -820,7 +824,7 @@ final class Cachify {
 
 	public static function flush_notice()
 	{
-		/* Kein Admin */
+		/* No Admin */
 		if ( ! is_admin_bar_showing() OR ! apply_filters('cachify_user_can_flush_cache', current_user_can('manage_options')) ) {
 			return false;
 		}
@@ -833,12 +837,12 @@ final class Cachify {
 
 
 	/**
-	* Löschung des Cache beim Kommentar-Editieren
+	* Remove page from cache or flush on comment edit
 	*
 	* @since   0.1.0
 	* @change  2.1.2
 	*
-	* @param   integer  $id  ID des Kommentars
+	* @param   integer  $id  Comment ID
 	*/
 
 	public static function edit_comment($id)
@@ -854,14 +858,14 @@ final class Cachify {
 
 
 	/**
-	* Löschung des Cache beim neuen Kommentar
+	* Remove page from cache or flush on new comment
 	*
 	* @since   0.1.0
 	* @change  2.1.2
 	*
-	* @param   mixed  $approved  Kommentar-Status
-	* @param   array  $comment   Array mit Eigenschaften
-	* @return  mixed  $approved  Kommentar-Status
+	* @param   mixed  $approved  Comment status
+	* @param   array  $comment   Array of properties
+	* @return  mixed             Comment status
 	*/
 
 	public static function pre_comment($approved, $comment)
@@ -880,14 +884,14 @@ final class Cachify {
 
 
 	/**
-	* Löschung des Cache beim Editieren der Kommentare
+	* Remove page from cache or flush on comment edit
 	*
 	* @since   0.1
 	* @change  2.1.2
 	*
-	* @param   string  $new_status  Neuer Status
-	* @param   string  $old_status  Alter Status
-	* @param   object  $comment     Array mit Eigenschaften
+	* @param   string  $new_status  New status
+	* @param   string  $old_status  Old status
+	* @param   object  $comment     The comment
 	*/
 
 	public static function touch_comment($new_status, $old_status, $comment)
@@ -903,7 +907,7 @@ final class Cachify {
 
 
 	/**
-	* Generierung von Publish-Hooks für Custom Post Types
+	* Generate publish hook for custom post types
 	*
 	* @since   2.1.7  Make the function public
 	* @since   2.0.3
@@ -947,13 +951,14 @@ final class Cachify {
 
 
 	/**
-	* Removes the post type cache on post updates
-	*
-	* @since   2.0.3
-	* @change  2.2.2
-	*
-	* @param   integer  $post_ID  Post ID
-	*/
+	 * Removes the post type cache on post updates
+	 *
+	 * @since   2.0.3
+	 * @change  2.2.2
+	 *
+	 * @param   integer $post_ID  Post ID
+	 * @param   object  $post     Post object
+	 */
 
 	public static function publish_post_types($post_ID, $post)
 	{
@@ -1052,12 +1057,12 @@ final class Cachify {
 
 
 	/**
-	* Rückgabe der Cache-Gültigkeit
+	* Get cache validity
 	*
 	* @since   2.0.0
 	* @change  2.1.7
 	*
-	* @return  intval    Gültigkeit in Sekunden
+	* @return  integer    Validity period in seconds
 	*/
 
 	private static function _cache_expires()
@@ -1067,13 +1072,13 @@ final class Cachify {
 
 
 	/**
-	* Rückgabe des Cache-Hash-Wertes
+	* Get hash value for caching
 	*
 	* @since   0.1
 	* @change  2.0
 	*
-	* @param   string  $url  URL für den Hash-Wert [optional]
-	* @return  string        Cachify-Hash-Wert
+	* @param   string  $url  URL to hash [optional]
+	* @return  string        Cachify hash value
 	*/
 
 	private static function _cache_hash($url = '')
@@ -1086,13 +1091,13 @@ final class Cachify {
 
 
 	/**
-	* Splittung nach Komma
+	* Split by comma
 	*
 	* @since   0.9.1
 	* @change  1.0
 	*
-	* @param   string  $input  Zu splittende Zeichenkette
-	* @return  array           Konvertierter Array
+	* @param   string  $input  String to split
+	* @return  array           Splitted values
 	*/
 
 	private static function _preg_split($input)
@@ -1102,12 +1107,12 @@ final class Cachify {
 
 
 	/**
-	* Prüfung auf Index
+	* Check for index page
 	*
 	* @since   0.6
 	* @change  1.0
 	*
-	* @return  boolean  TRUE bei Index
+	* @return  boolean  TRUE if index
 	*/
 
 	private static function _is_index()
@@ -1117,12 +1122,12 @@ final class Cachify {
 
 
 	/**
-	* Prüfung auf Mobile Devices
+	* Check for mobile devices
 	*
 	* @since   0.9.1
 	* @change  2.2.2
 	*
-	* @return  boolean  TRUE bei Mobile
+	* @return  boolean  TRUE if mobile
 	*/
 
 	private static function _is_mobile()
@@ -1132,17 +1137,17 @@ final class Cachify {
 
 
 	/**
-	* Prüfung auf eingeloggte und kommentierte Nutzer
+	* Check if user is logged in or marked
 	*
 	* @since   2.0.0
 	* @change  2.0.5
 	*
-	* @return  boolean  $diff  TRUE bei "vermerkten" Nutzern
+	* @return  boolean  $diff  TRUE on "marked" users
 	*/
 
 	private static function _is_logged_in()
 	{
-		/* Eingeloggt */
+		/* Logged in */
 		if ( is_user_logged_in() ) {
 			return true;
 		}
@@ -1152,7 +1157,7 @@ final class Cachify {
 			return false;
 		}
 
-		/* Loopen */
+		/* Loop */
 		foreach ( $_COOKIE as $k => $v) {
 			if ( preg_match('/^(wp-postpass|wordpress_logged_in|comment_author)_/', $k) ) {
 				return true;
@@ -1162,12 +1167,12 @@ final class Cachify {
 
 
 	/**
-	* Definition der Ausnahmen für den Cache
+	* Define exclusions for caching
 	*
 	* @since   0.2
 	* @change  2.1.7
 	*
-	* @return  boolean  TRUE bei Ausnahmen
+	* @return  boolean  TRUE on exclusion
 	*
 	* @hook    boolean  cachify_skip_cache
 	*/
@@ -1226,13 +1231,13 @@ final class Cachify {
 
 
 	/**
-	* Minimierung des HTML-Codes
+	* Minify HTML code
 	*
 	* @since   0.9.2
 	* @change  2.0.9
 	*
-	* @param   string  $data  Zu minimierender Datensatz
-	* @return  string  $data  Minimierter Datensatz
+	* @param   string  $data  Original HTML code
+	* @return  string         Minified code
 	*
 	* @hook    array   cachify_minify_ignore_tags
 	*/
@@ -1294,10 +1299,12 @@ final class Cachify {
 
 
 	/**
-	* Zurücksetzen des kompletten Cache
+	* Flush total cache
 	*
 	* @since   0.1
 	* @change  2.0
+	*
+	* @param bool  $clear_all_methods  Flush all caching methods (default: FALSE)
 	*/
 
 	public static function flush_total_cache($clear_all_methods = false)
@@ -1329,23 +1336,23 @@ final class Cachify {
 
 
 	/**
-	* Zuweisung des Cache
+	* Assign the cache
 	*
 	* @since   0.1
 	* @change  2.0
 	*
-	* @param   string  $data  Inhalt der Seite
-	* @return  string  $data  Inhalt der Seite
+	* @param   string  $data  Content of the page
+	* @return  string         Content of the page
 	*/
 
 	public static function set_cache($data)
 	{
-		/* Leer? */
+		/* Empty? */
 		if ( empty($data) ) {
 			return '';
 		}
 
-		/* Speicherung */
+		/* Save */
 		call_user_func(
 			array(
 				self::$method,
@@ -1361,7 +1368,7 @@ final class Cachify {
 
 
 	/**
-	* Verwaltung des Cache
+	* Manage the cache
 	*
 	* @since   0.1
 	* @change  2.0
@@ -1369,12 +1376,12 @@ final class Cachify {
 
 	public static function manage_cache()
 	{
-		/* Kein Caching? */
+		/* No caching? */
 		if ( self::_skip_cache() ) {
 			return;
 		}
 
-		/* Daten im Cache */
+		/* Data present in cache */
 		$cache = call_user_func(
 			array(
 				self::$method,
@@ -1383,13 +1390,13 @@ final class Cachify {
 			self::_cache_hash()
 		);
 
-		/* Kein Cache? */
+		/* No cache? */
 		if ( empty($cache) ) {
 			ob_start('Cachify::set_cache');
 			return;
 		}
 
-		/* Cache verarbeiten */
+		/* Process cache */
 		call_user_func(
 			array(
 				self::$method,
@@ -1401,11 +1408,13 @@ final class Cachify {
 
 
 	/**
-	* Einbindung von CSS
-	*
-	* @since   1.0
-	* @change  2.1.3
-	*/
+	 * Register CSS
+	 *
+	 * @since   1.0
+	 * @change  2.1.3
+	 *
+	 * @param   string $hook  Current hook
+	 */
 
 	public static function add_admin_resources($hook)
 	{
@@ -1523,7 +1532,7 @@ final class Cachify {
 
 
 	/**
-	* Einfügen der Optionsseite
+	* Add options page
 	*
 	* @since   1.0
 	* @change  2.2.2
@@ -1545,12 +1554,13 @@ final class Cachify {
 
 
 	/**
-	* Verfügbare Cache-Methoden
+	* Available caching methods
 	*
 	* @since  2.0.0
 	* @change 2.1.3
 	*
-	* @param  array  $methods  Array mit verfügbaren Arten
+	* @param  array  $methods  Array of all available methods
+	* @return array            Array of actually available methods
 	*/
 
 	private static function _method_select()
@@ -1618,7 +1628,7 @@ final class Cachify {
 	}
 
 	/**
-	* Registrierung der Settings
+	* Register settings
 	*
 	* @since   1.0
 	* @change  1.0
@@ -1638,13 +1648,13 @@ final class Cachify {
 
 
 	/**
-	* Validierung der Optionsseite
+	* Validate options
 	*
 	* @since   1.0.0
 	* @change  2.1.3
 	*
-	* @param   array  $data  Array mit Formularwerten
-	* @return  array         Array mit geprüften Werten
+	* @param   array  $data  Array of form values
+	* @return  array         Array of validated values
 	*/
 
 	public static function validate_options($data)
@@ -1654,10 +1664,10 @@ final class Cachify {
 			return;
 		}
 
-		/* Cache leeren */
+		/* Flush cache */
 		self::flush_total_cache(true);
 
-		/* Hinweis */
+		/* Notification */
 		if ( self::$options['use_apc'] != $data['use_apc'] && $data['use_apc'] >= self::METHOD_APC ) {
 			add_settings_error(
 				'cachify_method_tip',
@@ -1670,7 +1680,7 @@ final class Cachify {
 			);
 		}
 
-		/* Rückgabe */
+		/* Return */
 		return array(
 			'only_guests'	 	=> (int)(!empty($data['only_guests'])),
 			'compress_html'	 	=> (int)$data['compress_html'],
@@ -1684,7 +1694,7 @@ final class Cachify {
 
 
 	/**
-	* Darstellung der Optionsseite
+	* Display options page
 	*
 	* @since   1.0
 	* @change  2.2.2

--- a/inc/cachify_apc.class.php
+++ b/inc/cachify_apc.class.php
@@ -42,14 +42,14 @@ final class Cachify_APC {
 
 
 	/**
-	* Speicherung im Cache
+	* Store item in cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string   $hash      Hash des Eintrags
-	* @param   string   $data      Inhalt des Eintrags
-	* @param   integer  $lifetime  Lebensdauer des Eintrags
+	* @param   string   $hash      Hash of the entry
+	* @param   string   $data      Content of the entry
+	* @param   integer  $lifetime  Lifetime of the entry
 	*/
 
 	public static function store_item($hash, $data, $lifetime)
@@ -69,18 +69,18 @@ final class Cachify_APC {
 
 
 	/**
-	* Lesen aus dem Cache
+	* Read item from cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string  $hash  Hash des Eintrags
-	* @return  mixed   $diff  Wert des Eintrags
+	* @param   string  $hash  Hash of the entry
+	* @return  mixed          Content of the entry
 	*/
 
 	public static function get_item($hash)
 	{
-		/* Leer? */
+		/* Empty? */
 		if ( empty($hash) ) {
 			wp_die('APC get item: Empty input.');
 		}
@@ -90,29 +90,29 @@ final class Cachify_APC {
 
 
 	/**
-	* Entfernung aus dem Cache
+	* Delete item from cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string  $hash  Hash des Eintrags
-	* @param   string  $url   URL des Eintrags [optional]
+	* @param   string  $hash  Hash of the entry
+	* @param   string  $url   URL of the entry [optional]
 	*/
 
 	public static function delete_item($hash, $url = '')
 	{
-		/* Leer? */
+		/* Empty? */
 		if ( empty($hash) ) {
 			wp_die('APC delete item: Empty input.');
 		}
 
-		/* Löschen */
+		/* Delete */
 		apc_delete($hash);
 	}
 
 
 	/**
-	* Leerung des Cache
+	* Clear the cache
 	*
 	* @since   2.0.0
 	* @change  2.0.7
@@ -129,7 +129,7 @@ final class Cachify_APC {
 
 
 	/**
-	* Ausgabe des Cache
+	* Print the cache
 	*
 	* @since   2.0
 	* @change  2.0
@@ -142,20 +142,20 @@ final class Cachify_APC {
 
 
 	/**
-	* Ermittlung der Cache-Größe
+	* Get the cache size
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @return  mixed  $diff  Cache-Größe
+	* @return  mixed  Cache size
 	*/
 
 	public static function get_stats()
 	{
-		/* Infos */
+		/* Info */
 		$data = apc_cache_info('user');
 
-		/* Leer */
+		/* Empty */
 		if ( empty($data['mem_size']) ) {
 			return NULL;
 		}
@@ -165,12 +165,12 @@ final class Cachify_APC {
 
 
 	/**
-	* Generierung der Signatur
+	* Generate signature
 	*
 	* @since   2.0
 	* @change  2.0.5
 	*
-	* @return  string  $diff  Signatur als String
+	* @return  string  Signature string
 	*/
 
 	private static function _cache_signatur()

--- a/inc/cachify_db.class.php
+++ b/inc/cachify_db.class.php
@@ -42,19 +42,19 @@ final class Cachify_DB {
 
 
 	/**
-	* Speicherung im Cache
+	* Store item in cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string   $hash      Hash des Eintrags
-	* @param   string   $data      Inhalt des Eintrags
-	* @param   integer  $lifetime  Lebensdauer des Eintrags
+	* @param   string   $hash      Hash of the entry
+	* @param   string   $data      Content of the entry
+	* @param   integer  $lifetime  Lifetime of the entry
 	*/
 
 	public static function store_item($hash, $data, $lifetime)
 	{
-		/* Leer? */
+		/* Empty? */
 		if ( empty($hash) or empty($data) ) {
 			wp_die('DB add item: Empty input.');
 		}
@@ -77,13 +77,13 @@ final class Cachify_DB {
 
 
 	/**
-	* Lesen aus dem Cache
+	* Read item from cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string  $hash  Hash des Eintrags
-	* @return  mixed   $diff  Wert des Eintrags
+	* @param   string  $hash  Hash of the entry
+	* @return  mixed          Content of the entry
 	*/
 
 	public static function get_item($hash)
@@ -98,29 +98,29 @@ final class Cachify_DB {
 
 
 	/**
-	* Entfernung aus dem Cache
+	* Delete item from cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string  $hash  Hash des Eintrags
-	* @param   string  $url   URL des Eintrags [optional]
+	* @param   string  $hash  Hash of the entry
+	* @param   string  $url   URL of the entry [optional]
 	*/
 
 	public static function delete_item($hash, $url = '')
 	{
-		/* Leer? */
+		/* Empty? */
 		if ( empty($hash) ) {
 			wp_die('DB delete item: Empty input.');
 		}
 
-		/* Löschen */
+		/* Delete */
 		delete_transient($hash);
 	}
 
 
 	/**
-	* Leerung des Cache
+	* Clear the cache
 	*
 	* @since   2.0
 	* @change  2.0
@@ -131,23 +131,23 @@ final class Cachify_DB {
 		/* Init */
 		global $wpdb;
 
-		/* Löschen */
+		/* Clear */
 		$wpdb->query("DELETE FROM `" .$wpdb->options. "` WHERE `option_name` LIKE ('\_transient%.cachify')");
 	}
 
 
 	/**
-	* Ausgabe des Cache
+	* Print the cache
 	*
 	* @since   2.0
 	* @change  2.0.2
 	*
-	* @param   array  $cache  Array mit Cache-Werten
+	* @param   array  $cache  Array of cache values
 	*/
 
 	public static function print_cache($cache)
 	{
-		/* Kein Array? */
+		/* No array? */
 		if ( ! is_array($cache) ) {
 			return;
 		}
@@ -155,23 +155,23 @@ final class Cachify_DB {
 		/* Content */
 		echo $cache['data'];
 
-		/* Signatur */
+		/* Signature */
 		if ( isset($cache['meta']) ) {
 			echo self::_cache_signatur($cache['meta']);
 		}
 
-		/* Raus */
+		/* Quit */
 		exit;
 	}
 
 
 	/**
-	* Ermittlung der Cache-Größe
+	* Get the cache size
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @return  integer  $diff  Spaltengröße
+	* @return  integer  Column size
 	*/
 
 	public static function get_stats()
@@ -179,7 +179,7 @@ final class Cachify_DB {
 		/* Init */
 		global $wpdb;
 
-		/* Auslesen */
+		/* Read */
 		return $wpdb->get_var(
 			"SELECT SUM( CHAR_LENGTH(option_value) ) FROM `" .$wpdb->options. "` WHERE `option_name` LIKE ('\_transient%.cachify')"
 		);
@@ -187,18 +187,18 @@ final class Cachify_DB {
 
 
 	/**
-	* Generierung der Signatur
+	* Generate signature
 	*
 	* @since   2.0
 	* @change  2.0.5
 	*
-	* @param   array   $meta  Inhalt der Metadaten
-	* @return  string  $diff  Signatur als String
+	* @param   array   $meta  Content of metadata
+	* @return  string         Signature string
 	*/
 
 	private static function _cache_signatur($meta)
 	{
-		/* Kein Array? */
+		/* No array? */
 		if ( ! is_array($meta) ) {
 			return;
 		}
@@ -227,12 +227,12 @@ final class Cachify_DB {
 
 
 	/**
-	* Rückgabe der Query-Anzahl
+	* Return query count
 	*
 	* @since   0.1
 	* @change  2.0
 	*
-	* @return  intval  $diff  Query-Anzahl
+	* @return  integer  Numbe rof queries
 	*/
 
 	private static function _page_queries()
@@ -242,12 +242,12 @@ final class Cachify_DB {
 
 
 	/**
-	* Rückgabe der Ausführungszeit
+	* REturn execution time
 	*
 	* @since   0.1
 	* @change  2.0
 	*
-	* @return  intval  $diff  Anzahl der Sekunden
+	* @return  integer  Execution time in seconds
 	*/
 
 	private static function _page_timer()
@@ -257,12 +257,12 @@ final class Cachify_DB {
 
 
 	/**
-	* Rückgabe des Speicherverbrauchs
+	* Return memory consumption
 	*
 	* @since   0.7
 	* @change  2.0
 	*
-	* @return  string  $diff  Konvertierter Größenwert
+	* @return  string  Formatted memory size
 	*/
 
 	private static function _page_memory()

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -42,14 +42,14 @@ final class Cachify_HDD {
 
 
 	/**
-	* Speicherung im Cache
+	* Store item in cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string   $hash      Hash des Eintrags [optional]
-	* @param   string   $data      Inhalt des Eintrags
-	* @param   integer  $lifetime  Lebensdauer des Eintrags [optional]
+	* @param   string   $hash      Hash  of the entry [optional]
+	* @param   string   $data      Content of the entry
+	* @param   integer  $lifetime  Lifetime of the entry [optional]
 	*/
 
 	public static function store_item($hash, $data, $lifetime)
@@ -67,12 +67,12 @@ final class Cachify_HDD {
 
 
 	/**
-	* Lesen aus dem Cache
+	* Read item from cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @return  boolean  $diff  TRUE wenn Cache vorhanden
+	* @return  boolean  $diff  TRUE if cache is present
 	*/
 
 	public static function get_item()
@@ -84,23 +84,23 @@ final class Cachify_HDD {
 
 
 	/**
-	* Entfernen aus dem Cache
+	* Delete item from cache
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string   $hash  Hash des Eintrags [optional]
-	* @param   string   $url   URL des Eintrags
+	* @param   string   $hash  Hash of the entry [optional]
+	* @param   string   $url   URL of the entry
 	*/
 
 	public static function delete_item($hash = '', $url)
 	{
-		/* Leer? */
+		/* Empty? */
 		if ( empty($url) ) {
 			wp_die('HDD delete item: Empty input.');
 		}
 
-		/* Löschen */
+		/* Delete */
 		self::_clear_dir(
 			self::_file_path($url)
 		);
@@ -108,7 +108,7 @@ final class Cachify_HDD {
 
 
 	/**
-	* Leerung des Cache
+	* Clear the cache
 	*
 	* @since   2.0
 	* @change  2.0
@@ -123,7 +123,7 @@ final class Cachify_HDD {
 
 
 	/**
-	* Ausgabe des Cache
+	* Print the cache
 	*
 	* @since   2.0
 	* @change  2.0
@@ -136,12 +136,12 @@ final class Cachify_HDD {
 
 
 	/**
-	* Ermittlung der Cache-Größe
+	* Get the cache size
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @return  integer  $diff  Ordnergröße
+	* @return  integer  Directory size
 	*/
 
 	public static function get_stats()
@@ -151,12 +151,12 @@ final class Cachify_HDD {
 
 
 	/**
-	* Generierung der Signatur
+	* Generate signature
 	*
 	* @since   2.0
 	* @change  2.0.5
 	*
-	* @return  string  $diff  Signatur als String
+	* @return  string  Signature string
 	*/
 
 	private static function _cache_signatur()
@@ -174,29 +174,29 @@ final class Cachify_HDD {
 
 
 	/**
-	* Initialisierung des Cache-Speichervorgangs
+	* Initialize caching process
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string  $data  Cache-Inhalt
+	* @param   string  $data  Cache content
 	*/
 
 	private static function _create_files($data)
 	{
-		/* Ordner anlegen */
+		/* Create directory */
 		if ( ! wp_mkdir_p( self::_file_path() ) ) {
 			wp_die('Unable to create directory.');
 		}
 
-		/* Dateien schreiben */
+		/* Write to file */
 		self::_create_file( self::_file_html(), $data );
 		self::_create_file( self::_file_gzip(), gzencode($data, 9) );
 	}
 
 
 	/**
-	* Anlegen der Cache-Datei
+	* Create cache file
 	*
 	* @since   2.0
 	* @change  2.0
@@ -207,12 +207,12 @@ final class Cachify_HDD {
 
 	private static function _create_file($file, $data)
 	{
-		/* Beschreibbar? */
+		/* Writable? */
 		if ( ! $handle = @fopen($file, 'wb') ) {
 			wp_die('Could not write file.');
 		}
 
-		/* Schreiben */
+		/* Write */
 		@fwrite($handle, $data);
 		fclose($handle);
 		clearstatcache();
@@ -227,40 +227,40 @@ final class Cachify_HDD {
 
 
 	/**
-	* Rekrusive Leerung eines Ordners
+	* Clear directory recursively
 	*
 	* @since   2.0
 	* @change  2.0.5
 	*
-	* @param   string  $dir  Ordnerpfad
+	* @param   string  $dir  Directory path
 	*/
 
 	private static function _clear_dir($dir) {
-		/* Weg mit dem Slash */
+		/* Remote training slash */
 		$dir = untrailingslashit($dir);
 
-		/* Ordner? */
+		/* Is directory? */
 		if ( ! is_dir($dir) ) {
 			return;
 		}
 
-		/* Einlesen */
+		/* Read */
 		$objects = array_diff(
 			scandir($dir),
 			array('..', '.')
 		);
 
-		/* Leer? */
+		/* Empty? */
 		if ( empty($objects) ) {
 			return;
 		}
 
-		/* Loopen */
+		/* Loop over items */
 		foreach ( $objects as $object ) {
-			/* Um Pfad erweitern */
+			/* Expand path */
 			$object = $dir. DIRECTORY_SEPARATOR .$object;
 
-			/* Ordner/Datei */
+			/* Directory or file */
 			if ( is_dir($object) ) {
 				self::_clear_dir($object);
 			} else {
@@ -268,38 +268,38 @@ final class Cachify_HDD {
 			}
 		}
 
-		/* Killen */
+		/* Remove directory */
 		@rmdir($dir);
 
-		/* Aufräumen */
+		/* CleanUp */
 		clearstatcache();
 	}
 
 
 	/**
-	* Ermittlung der Ordnergröße
+	* Get directory size
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string  $dir   Ordnerpfad
-	* @return  mixed   $size  Ordnergröße
+	* @param   string  $dir   Directory path
+	* @return  mixed          Directory size
 	*/
 
 	public static function _dir_size($dir = '.')
 	{
-		/* Ordner? */
+		/* Is directory? */
 		if ( ! is_dir($dir) ) {
 			return;
 		}
 
-		/* Einlesen */
+		/* Read */
 		$objects = array_diff(
 			scandir($dir),
 			array('..', '.')
 		);
 
-		/* Leer? */
+		/* Empty? */
 		if ( empty($objects) ) {
 			return;
 		}
@@ -307,12 +307,12 @@ final class Cachify_HDD {
 		/* Init */
 		$size = 0;
 
-		/* Loopen */
+		/* Loop over items */
 		foreach ( $objects as $object ) {
-			/* Um Pfad erweitern */
+			/* Expand path */
 			$object = $dir. DIRECTORY_SEPARATOR .$object;
 
-			/* Ordner/Datei */
+			/* Directory or file */
 			if ( is_dir($object) ) {
 				$size += self::_dir_size($object);
 			} else {
@@ -325,13 +325,13 @@ final class Cachify_HDD {
 
 
 	/**
-	* Pfad der Cache-Datei
+	* Path to cache file
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @param   string  $path  Request-URI oder Permalink [optional]
-	* @return  string  $diff  Pfad zur Cache-Datei
+	* @param   string  $path  Request-URI or Permalink [optional]
+	* @return  string         Path to cache file
 	*/
 
 	private static function _file_path($path = NULL)
@@ -362,12 +362,12 @@ final class Cachify_HDD {
 
 
 	/**
-	* Pfad der HTML-Datei
+	* Path to HTML file
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @return  string  $diff  Pfad zur HTML-Datei
+	* @return  string  Path to HTML file
 	*/
 
 	private static function _file_html()
@@ -377,12 +377,12 @@ final class Cachify_HDD {
 
 
 	/**
-	* Pfad der GZIP-Datei
+	* Path to GZIP file
 	*
 	* @since   2.0
 	* @change  2.0
 	*
-	* @return  string  $diff  Pfad zur GZIP-Datei
+	* @return  string  Path to GZIP file
 	*/
 
 	private static function _file_gzip()

--- a/inc/cachify_memcached.class.php
+++ b/inc/cachify_memcached.class.php
@@ -52,14 +52,14 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Speicherung im Cache
+	* Store item in cache
 	*
 	* @since   2.0.7
 	* @change  2.0.7
 	*
-	* @param   string   $hash      Hash des Eintrags
-	* @param   string   $data      Inhalt des Eintrags
-	* @param   integer  $lifetime  Lebensdauer des Eintrags
+	* @param   string   $hash      Hash of the entry
+	* @param   string   $data      Content of the entry
+	* @param   integer  $lifetime  Lifetime of the entry
 	*/
 
 	public static function store_item($hash, $data, $lifetime)
@@ -84,13 +84,13 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Lesen aus dem Cache
+	* Read item from cache
 	*
 	* @since   2.0.7
 	* @change  2.0.7
 	*
-	* @param   string  $hash  Hash des Eintrags
-	* @return  mixed   $diff  Wert des Eintrags
+	* @param   string  $hash  Hash of the entry
+	* @return  mixed          Content of the entry
 	*/
 
 	public static function get_item($hash)
@@ -108,13 +108,13 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Entfernung aus dem Cache
+	* Delete item from cache
 	*
 	* @since   2.0.7
 	* @change  2.0.7
 	*
-	* @param   string  $hash  Hash des Eintrags
-	* @param   string  $url   URL des Eintrags [optional]
+	* @param   string  $hash  Hash of the entry
+	* @param   string  $url   URL of the entry [optional]
 	*/
 
 	public static function delete_item($hash, $url = '')
@@ -132,7 +132,7 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Leerung des Cache
+	* Clear the cache
 	*
 	* @since   2.0.7
 	* @change  2.0.7
@@ -151,7 +151,7 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Ausgabe des Cache
+	* Print the cache
 	*
 	* @since   2.0.7
 	* @change  2.0.7
@@ -164,12 +164,12 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Ermittlung der Cache-Größe
+	* Get the cache size
 	*
 	* @since   2.0.7
 	* @change  2.0.7
 	*
-	* @return  mixed  $diff  Cache-Größe
+	* @return  mixed  Cache size
 	*/
 
 	public static function get_stats()
@@ -179,7 +179,7 @@ final class Cachify_MEMCACHED {
 			wp_die('MEMCACHE: Not enabled.');
 		}
 
-		/* Infos */
+		/* Info */
 		$data = self::$_memcached->getStats();
 
 		/* No stats? */
@@ -190,7 +190,7 @@ final class Cachify_MEMCACHED {
 		/* Get first key */
 		$data = $data[key($data)];
 
-		/* Leer */
+		/* Empty */
 		if ( empty($data['bytes']) ) {
 			return NULL;
 		}
@@ -200,12 +200,12 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Generierung der Signatur
+	* Generate signature
 	*
 	* @since   2.0.7
 	* @change  2.0.7
 	*
-	* @return  string  $diff  Signatur als String
+	* @return  string  Signature string
 	*/
 
 	private static function _cache_signatur()
@@ -223,13 +223,13 @@ final class Cachify_MEMCACHED {
 
 
 	/**
-	* Pfad der Cache-Datei
+	* Path of cache file
 	*
 	* @since   2.0.7
 	* @change  2.0.7
 	*
-	* @param   string  $path  Request-URI oder Permalink [optional]
-	* @return  string  $diff  Pfad zur Cache-Datei
+	* @param   string  $path  Request-URI or Permalink [optional]
+	* @return  string         Path to cache file
 	*/
 
 	private static function _file_path($path = NULL)
@@ -255,7 +255,7 @@ final class Cachify_MEMCACHED {
 	*
 	* @hook    array  cachify_memcached_servers  Array with memcached servers
 	*
-	* @return  boolean  true/false  TRUE bei Erfolg
+	* @return  boolean  true/false  TRUE on success
 	*/
 
 	private static function _connect_server()


### PR DESCRIPTION
Although if the main dev team is German, the code is available to the public and the common language should be English. Some parts already are, but mostly older comments are kept German.

Cleaned up the mixture and corrected some PHPDoc values, so that it's consistent now.
No code has been changed, shouldn't be worth an issue.