### PR TITLE
better hdd cache invalidation

### DIFF
--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -117,7 +117,8 @@ final class Cachify_HDD {
 	public static function clear_cache()
 	{
 		self::_clear_dir(
-			CACHIFY_CACHE_DIR
+			CACHIFY_CACHE_DIR,
+			true
 		);
 	}
 
@@ -227,15 +228,16 @@ final class Cachify_HDD {
 
 
 	/**
-	* Clear directory recursively
+	* Clear directory
 	*
 	* @since   2.0
 	* @change  2.0.5
 	*
-	* @param   string  $dir  Directory path
+	* @param   string   $dir        Directory path
+	* @param   boolean  $recursive  clear subdirectories
 	*/
 
-	private static function _clear_dir($dir) {
+	private static function _clear_dir($dir, $recursive = false) {
 		/* Remote training slash */
 		$dir = untrailingslashit($dir);
 
@@ -261,15 +263,17 @@ final class Cachify_HDD {
 			$object = $dir. DIRECTORY_SEPARATOR .$object;
 
 			/* Directory or file */
-			if ( is_dir($object) ) {
-				self::_clear_dir($object);
+			if ( is_dir($object) && $recursive ) {
+				self::_clear_dir($object, $recursive);
 			} else {
 				unlink($object);
 			}
 		}
 
 		/* Remove directory */
-		@rmdir($dir);
+		if( $recursive ) {
+			@rmdir($dir);
+		}
 
 		/* CleanUp */
 		clearstatcache();

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -271,7 +271,7 @@ final class Cachify_HDD {
 		}
 
 		/* Remove directory */
-		if( $recursive ) {
+		if ( $recursive ) {
 			@rmdir($dir);
 		}
 


### PR DESCRIPTION
Assume `_cachify_remove_post_type_cache_on_update` is set to **1** (_only clear page cache_) for the current user.
This pull fixes the issue that [`_clear_dir`](https://github.com/pluginkollektiv/cachify/blob/master/inc/cachify_hdd.class.php#L238) deletes everything that's heirarchically below the post that is being saved.

This problem would also happen for any other hierarchical post type where any parent also invalidates all it's children's cache.
The tradeoff with my implementation is that one might find orphaned directories in their cache directory.
For example saving the page with permalink `/test/` would leave an empty directory of `cache/cachify/<hostname>/test/`

The other caching methods might need a similar fix, I haven't checked those out.