### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[**.css]
+indent_style = tab
+indent_size = 4
+
+[**.html]
+indent_style = tab
+indent_size = 4
+
+[**.js]
+indent_style = tab
+indent_size = 4
+
+[**.php]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
`.editorconfig` file to make text editors with respective plugins automatically pick up several code style settings without changing global text editor settings. [A wide variety](http://editorconfig.org/#download) of plugins are available.

Documentation: http://editorconfig.org/