### PR TITLE
Remove undefined $path variable.

### DIFF
--- a/inc/setup/cachify.hdd.htaccess.php
+++ b/inc/setup/cachify.hdd.htaccess.php
@@ -81,7 +81,7 @@ $ending = '/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:C
 			$beginning,
 			WP_CONTENT_DIR,
 			$middle,
-			wp_make_link_relative( content_url( $path ) ),
+			wp_make_link_relative( content_url() ),
 		$ending ); ?></pre>
 	</div>
 


### PR DESCRIPTION
Fixes #78.

I believe the `$path` variable can be simply dropped, because `content_url` path is extended via [$ending](https://github.com/pluginkollektiv/cachify/blob/master/inc/setup/cachify.hdd.htaccess.php#L41) variable that is [appended](https://github.com/pluginkollektiv/cachify/blob/master/inc/setup/cachify.hdd.htaccess.php#L85) to the path.