### PR TITLE
Escape translated string for HTML.

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -545,7 +545,7 @@ final class Cachify {
 						),
 						admin_url( 'options-general.php' )
 					),
-					__( 'Settings', 'cachify' )
+					esc_html__( 'Settings', 'cachify' )
 				)
 			)
 		);


### PR DESCRIPTION
Fixes #84.