### PR TITLE
Remove unnecessary direct access guards in class-only files.

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1,6 +1,4 @@
 <?php
-/* Quit */
-defined( 'ABSPATH' ) || exit;
 
 /**
 * Cachify

--- a/inc/cachify_apc.class.php
+++ b/inc/cachify_apc.class.php
@@ -1,8 +1,5 @@
 <?php
 
-/* Quit */
-defined( 'ABSPATH' ) || exit;
-
 /**
 * Cachify_APC
 */

--- a/inc/cachify_db.class.php
+++ b/inc/cachify_db.class.php
@@ -1,8 +1,5 @@
 <?php
 
-/* Quit */
-defined( 'ABSPATH' ) || exit;
-
 /**
 * Cachify_DB
 */

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -1,8 +1,5 @@
 <?php
 
-/* Quit */
-defined( 'ABSPATH' ) || exit;
-
 /**
 * Cachify_HDD
 */

--- a/inc/cachify_memcached.class.php
+++ b/inc/cachify_memcached.class.php
@@ -1,8 +1,5 @@
 <?php
 
-/* Quit */
-defined( 'ABSPATH' ) or exit;
-
 /**
 * Cachify_MEMCACHED
 */


### PR DESCRIPTION
Fixes #90.

Side note: [`display_errors` should be never enabled on a production site.](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-there-path-disclosures-when-directly-loading-certain-files)