### PR TITLE
Do not reset cache expiration time to zero if input value is missing.

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1593,7 +1593,7 @@ final class Cachify {
 		return array(
 			'only_guests'      => (int) ( ! empty( $data['only_guests'] )),
 			'compress_html'    => (int) $data['compress_html'],
-			'cache_expires'    => (int) (@$data['cache_expires']),
+			'cache_expires'    => (int) ( isset( $data['cache_expires'] ) ? $data['cache_expires'] : self::$options['cache_expires'] ),
 			'without_ids'      => (string) sanitize_text_field( @$data['without_ids'] ),
 			'without_agents'   => (string) sanitize_text_field( @$data['without_agents'] ),
 			'use_apc'          => (int) $data['use_apc'],


### PR DESCRIPTION
Fixes #88. Relates to #99.