### PR TITLE
Add final missing return statement to Cachify::_is_logged_in().

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1095,6 +1095,8 @@ final class Cachify {
 				return true;
 			}
 		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
I noticed that final `return false` statement was missing in `Cachify::_is_logged_in()` (not a big issue, because null was returned instead of false, but should be fixed nevertheless).