### PR TITLE
Perform is_readable() check instead of using @ operator on readfile().

### DIFF
--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -106,7 +106,8 @@ final class Cachify_HDD {
 	 * @change  2.3
 	 */
 	public static function print_cache() {
-		$size = @readfile( self::_file_html() );
+		$filename = self::_file_html();
+		$size = is_readable( $filename ) ? readfile( $filename ) : false;
 		if ( ! empty ( $size ) ) {
 			/* Ok, cache file has been sent to output. */
 			exit;


### PR DESCRIPTION
Fixes issue mentioned in #98. Relates to #99.