### PR TITLE
Unify and cleanup HTML signature

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1026,7 +1026,7 @@ final class Cachify {
 	 * @return  bool  Show details in signature.
 	 */
 	private static function _signature_details() {
-		return isset(self::$options['sig_detail']) ? self::$options['sig_detail'] == 1 : false;
+		return self::$options['sig_detail'] === 1;
 	}
 
 	/**

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -475,7 +475,7 @@ final class Cachify {
 	 * Get options
 	 *
 	 * @since   2.0
-	 * @change  2.1.2
+	 * @change  2.3.0
 	 *
 	 * @return  array  Array of option values
 	 */
@@ -490,6 +490,7 @@ final class Cachify {
 				'without_agents' 	=> '',
 				'use_apc'		 	=> self::METHOD_DB,
 				'reset_on_comment'  => 0,
+				'sig_detail'        => 0,
 			)
 		);
 	}
@@ -1025,7 +1026,7 @@ final class Cachify {
 	 * @return  bool  Show details in signature.
 	 */
 	private static function _signature_details() {
-		return isset(self::$options['sig_detail']) ? self::$options['sig_detail'] == 1 : true;
+		return isset(self::$options['sig_detail']) ? self::$options['sig_detail'] == 1 : false;
 	}
 
 	/**

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1018,6 +1018,17 @@ final class Cachify {
 	}
 
 	/**
+	 * Determine if cache details should be printed in signature
+	 *
+	 * @since   2.3.0
+	 *
+	 * @return  bool  Show details in signature.
+	 */
+	private static function _signature_details() {
+		return isset(self::$options['sig_detail']) ? self::$options['sig_detail'] == 1 : true;
+	}
+
+	/**
 	 * Get hash value for caching
 	 *
 	 * @since   0.1
@@ -1290,7 +1301,8 @@ final class Cachify {
 			),
 			self::_cache_hash(),
 			self::_minify_cache( $data ),
-			self::_cache_expires()
+			self::_cache_expires(),
+			self::_signature_details()
 		);
 
 		return $data;
@@ -1319,6 +1331,7 @@ final class Cachify {
 					self::$method,
 					'print_cache',
 				),
+				self::_signature_details(),
 				$cache
 			);
 		}
@@ -1600,6 +1613,7 @@ final class Cachify {
 			'without_agents'   => (string) isset( $data['without_ids'] ) ? sanitize_text_field( $data['without_agents'] ) : '',
 			'use_apc'          => (int) $data['use_apc'],
 			'reset_on_comment' => (int) ( ! empty( $data['reset_on_comment'] )),
+			'sig_detail'       => (int) ( ! empty( $data['sig_detail'] )),
 		);
 	}
 

--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -93,6 +93,18 @@ defined( 'ABSPATH' ) || exit;
 				</label>
 			</td>
 		</tr>
+
+		<tr>
+			<th scope="row">
+				<?php esc_html_e( 'Cache signature', 'cachify' ); ?>
+			</th>
+			<td>
+				<label for="cachify_sig_detail">
+					<input type="checkbox" name="cachify[sig_detail]" id="cachify_sig_detail" value="1" <?php checked( '1', $options['sig_detail'] ); ?> />
+					<?php esc_html_e( 'Add additional details to Cachify signature (HTML comment)', 'cachify' ); ?>
+				</label>
+			</td>
+		</tr>
 	</table>
 
 	<?php submit_button() ?>

--- a/inc/cachify_apc.class.php
+++ b/inc/cachify_apc.class.php
@@ -33,13 +33,14 @@ final class Cachify_APC {
 	 * Store item in cache
 	 *
 	 * @since   2.0
-	 * @change  2.0
+	 * @change  2.3.0
 	 *
-	 * @param   string  $hash      Hash of the entry.
-	 * @param   string  $data      Content of the entry.
-	 * @param   integer $lifetime  Lifetime of the entry.
+	 * @param   string  $hash       Hash of the entry.
+	 * @param   string  $data       Content of the entry.
+	 * @param   integer $lifetime   Lifetime of the entry.
+	 * @param   bool    $sigDetail  Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime ) {
+	public static function store_item( $hash, $data, $lifetime, $sigDetail ) {
 		/* Empty? */
 		if ( empty( $hash ) || empty( $data ) ) {
 			wp_die( 'APC add item: Empty input.' );
@@ -48,7 +49,7 @@ final class Cachify_APC {
 		/* Store */
 		apc_store(
 			$hash,
-			gzencode( $data . self::_cache_signature(), 9 ),
+			gzencode( $data . self::_cache_signature( $sigDetail ), 9 ),
 			$lifetime
 		);
 	}
@@ -138,15 +139,16 @@ final class Cachify_APC {
 	 * Generate signature
 	 *
 	 * @since   2.0
-	 * @change  2.0.5
+	 * @change  2.3.0
 	 *
-	 * @return  string  Signature string
+	 * @param   bool $detail  Show details in signature.
+	 * @return  string        Signature string
 	 */
-	private static function _cache_signature() {
+	private static function _cache_signature( $detail ) {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | http://cachify.de',
-			'APC Cache',
+			( $detail ? 'APC Cache' : __( 'Generated', 'cachify' ) ),
 			date_i18n(
 				'd.m.Y H:i:s',
 				current_time( 'timestamp' )

--- a/inc/cachify_apc.class.php
+++ b/inc/cachify_apc.class.php
@@ -35,12 +35,12 @@ final class Cachify_APC {
 	 * @since   2.0
 	 * @change  2.3.0
 	 *
-	 * @param   string  $hash       Hash of the entry.
-	 * @param   string  $data       Content of the entry.
-	 * @param   integer $lifetime   Lifetime of the entry.
-	 * @param   bool    $sigDetail  Show details in signature.
+	 * @param   string  $hash        Hash of the entry.
+	 * @param   string  $data        Content of the entry.
+	 * @param   integer $lifetime    Lifetime of the entry.
+	 * @param   bool    $sig_detail  Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sigDetail ) {
+	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
 		/* Empty? */
 		if ( empty( $hash ) || empty( $data ) ) {
 			wp_die( 'APC add item: Empty input.' );
@@ -49,7 +49,7 @@ final class Cachify_APC {
 		/* Store */
 		apc_store(
 			$hash,
-			gzencode( $data . self::_cache_signature( $sigDetail ), 9 ),
+			gzencode( $data . self::_cache_signature( $sig_detail ), 9 ),
 			$lifetime
 		);
 	}

--- a/inc/cachify_db.class.php
+++ b/inc/cachify_db.class.php
@@ -172,8 +172,13 @@ final class Cachify_DB {
 		}
 
 		return sprintf(
-			"\n\n<!--\n%s\n%s\n%s\n%s\n-->",
+			"\n\n<!-- %s\n%s @ %s\n%s\n%s\n-->",
 			'Cachify | http://cachify.de',
+			'DB Cache',
+			date_i18n(
+				'd.m.Y H:i:s',
+				$meta['time']
+			),
 			sprintf(
 				'Without Cachify: %d DB queries, %s seconds, %s',
 				$meta['queries'],
@@ -185,10 +190,6 @@ final class Cachify_DB {
 				self::_page_queries(),
 				self::_page_timer(),
 				self::_page_memory()
-			),
-			sprintf(
-				'Generated: %s ago',
-				human_time_diff( $meta['time'], current_time( 'timestamp' ) )
 			)
 		);
 	}

--- a/inc/cachify_db.class.php
+++ b/inc/cachify_db.class.php
@@ -116,11 +116,12 @@ final class Cachify_DB {
 	 * Print the cache
 	 *
 	 * @since   2.0
-	 * @change  2.0.2
+	 * @change  2.3.0
 	 *
-	 * @param   array $cache  Array of cache values.
+	 * @param   bool  $sigDetail  Show details in signature.
+	 * @param   array $cache      Array of cache values.
 	 */
-	public static function print_cache( $cache ) {
+	public static function print_cache( $sigDetail, $cache ) {
 		/* No array? */
 		if ( ! is_array( $cache ) ) {
 			return;
@@ -131,7 +132,7 @@ final class Cachify_DB {
 
 		/* Signature */
 		if ( isset( $cache['meta'] ) ) {
-			echo self::_cache_signature( $cache['meta'] );
+			echo self::_cache_signature( $sigDetail, $cache['meta'] );
 		}
 
 		/* Quit */
@@ -160,38 +161,51 @@ final class Cachify_DB {
 	 * Generate signature
 	 *
 	 * @since   2.0
-	 * @change  2.0.5
+	 * @change  2.3.0
 	 *
-	 * @param   array $meta  Content of metadata.
-	 * @return  string       Signature string
+	 * @param   bool  $detail  Show details in signature
+	 * @param   array $meta    Content of metadata.
+	 * @return  string         Signature string
 	 */
-	private static function _cache_signature( $meta ) {
+	private static function _cache_signature( $detail, $meta ) {
 		/* No array? */
 		if ( ! is_array( $meta ) ) {
 			return;
 		}
 
-		return sprintf(
-			"\n\n<!-- %s\n%s @ %s\n%s\n%s\n-->",
-			'Cachify | http://cachify.de',
-			'DB Cache',
-			date_i18n(
-				'd.m.Y H:i:s',
-				$meta['time']
-			),
-			sprintf(
-				'Without Cachify: %d DB queries, %s seconds, %s',
-				$meta['queries'],
-				$meta['timer'],
-				$meta['memory']
-			),
-			sprintf(
-				'With Cachify: %d DB queries, %s seconds, %s',
-				self::_page_queries(),
-				self::_page_timer(),
-				self::_page_memory()
-			)
-		);
+		if ($detail) {
+			return sprintf(
+				"\n\n<!-- %s\n%s @ %s\n%s\n%s\n-->",
+				'Cachify | http://cachify.de',
+				'DB Cache',
+				date_i18n(
+					'd.m.Y H:i:s',
+					$meta['time']
+				),
+				sprintf(
+					'Without Cachify: %d DB queries, %s seconds, %s',
+					$meta['queries'],
+					$meta['timer'],
+					$meta['memory']
+				),
+				sprintf(
+					'With Cachify: %d DB queries, %s seconds, %s',
+					self::_page_queries(),
+					self::_page_timer(),
+					self::_page_memory()
+				)
+			);
+		} else {
+			return sprintf(
+				"\n\n<!-- %s\n%s @ %s -->",
+				'Cachify | http://cachify.de',
+				__( 'Generated', 'cachify' ),
+				date_i18n(
+					'd.m.Y H:i:s',
+					$meta['time']
+				)
+			);
+		}
 	}
 
 	/**

--- a/inc/cachify_db.class.php
+++ b/inc/cachify_db.class.php
@@ -118,10 +118,10 @@ final class Cachify_DB {
 	 * @since   2.0
 	 * @change  2.3.0
 	 *
-	 * @param   bool  $sigDetail  Show details in signature.
-	 * @param   array $cache      Array of cache values.
+	 * @param   bool  $sig_detail  Show details in signature.
+	 * @param   array $cache       Array of cache values.
 	 */
-	public static function print_cache( $sigDetail, $cache ) {
+	public static function print_cache( $sig_detail, $cache ) {
 		/* No array? */
 		if ( ! is_array( $cache ) ) {
 			return;
@@ -130,9 +130,9 @@ final class Cachify_DB {
 		/* Content */
 		echo $cache['data'];
 
-		/* Signature */
+		/* Signature - might contain runtime information, so it's generated at this point */
 		if ( isset( $cache['meta'] ) ) {
-			echo self::_cache_signature( $sigDetail, $cache['meta'] );
+			echo self::_cache_signature( $sig_detail, $cache['meta'] );
 		}
 
 		/* Quit */
@@ -163,7 +163,7 @@ final class Cachify_DB {
 	 * @since   2.0
 	 * @change  2.3.0
 	 *
-	 * @param   bool  $detail  Show details in signature
+	 * @param   bool  $detail  Show details in signature.
 	 * @param   array $meta    Content of metadata.
 	 * @return  string         Signature string
 	 */
@@ -173,7 +173,7 @@ final class Cachify_DB {
 			return;
 		}
 
-		if ($detail) {
+		if ( $detail ) {
 			return sprintf(
 				"\n\n<!-- %s\n%s @ %s\n%s\n%s\n-->",
 				'Cachify | http://cachify.de',

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -33,13 +33,14 @@ final class Cachify_HDD {
 	 * Store item in cache
 	 *
 	 * @since   2.0
-	 * @change  2.0
+	 * @change  2.3.0
 	 *
-	 * @param   string  $hash      Hash  of the entry [optional].
-	 * @param   string  $data      Content of the entry.
-	 * @param   integer $lifetime  Lifetime of the entry [optional].
+	 * @param   string  $hash       Hash  of the entry [optional].
+	 * @param   string  $data       Content of the entry.
+	 * @param   integer $lifetime   Lifetime of the entry [optional].
+	 * @param   bool    $sigDetail  Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime ) {
+	public static function store_item( $hash, $data, $lifetime, $sigDetail ) {
 		/* Empty? */
 		if ( empty( $data ) ) {
 			wp_die( 'HDD add item: Empty input.' );
@@ -47,7 +48,7 @@ final class Cachify_HDD {
 
 		/* Store data */
 		self::_create_files(
-			$data . self::_cache_signature()
+			$data . self::_cache_signature( $sigDetail )
 		);
 	}
 
@@ -130,15 +131,16 @@ final class Cachify_HDD {
 	 * Generate signature
 	 *
 	 * @since   2.0
-	 * @change  2.0.5
+	 * @change  2.3.0
 	 *
-	 * @return  string  Signature string
+	 * @param   bool $detail  Show details in signature
+	 * @return  string        Signature string
 	 */
-	private static function _cache_signature() {
+	private static function _cache_signature( $detail ) {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | http://cachify.de',
-			'HDD Cache',
+			( $detail ? 'HDD Cache' : __( 'Generated', 'cachify' ) ),
 			date_i18n(
 				'd.m.Y H:i:s',
 				current_time( 'timestamp' )

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -35,12 +35,12 @@ final class Cachify_HDD {
 	 * @since   2.0
 	 * @change  2.3.0
 	 *
-	 * @param   string  $hash       Hash  of the entry [optional].
-	 * @param   string  $data       Content of the entry.
-	 * @param   integer $lifetime   Lifetime of the entry [optional].
-	 * @param   bool    $sigDetail  Show details in signature.
+	 * @param   string  $hash        Hash  of the entry [optional].
+	 * @param   string  $data        Content of the entry.
+	 * @param   integer $lifetime    Lifetime of the entry [optional].
+	 * @param   bool    $sig_detail  Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sigDetail ) {
+	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
 		/* Empty? */
 		if ( empty( $data ) ) {
 			wp_die( 'HDD add item: Empty input.' );
@@ -48,7 +48,7 @@ final class Cachify_HDD {
 
 		/* Store data */
 		self::_create_files(
-			$data . self::_cache_signature( $sigDetail )
+			$data . self::_cache_signature( $sig_detail )
 		);
 	}
 
@@ -133,7 +133,7 @@ final class Cachify_HDD {
 	 * @since   2.0
 	 * @change  2.3.0
 	 *
-	 * @param   bool $detail  Show details in signature
+	 * @param   bool $detail  Show details in signature.
 	 * @return  string        Signature string
 	 */
 	private static function _cache_signature( $detail ) {

--- a/inc/cachify_memcached.class.php
+++ b/inc/cachify_memcached.class.php
@@ -42,13 +42,14 @@ final class Cachify_MEMCACHED {
 	 * Store item in cache
 	 *
 	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @change  2.3.0
 	 *
-	 * @param   string  $hash      Hash of the entry.
-	 * @param   string  $data      Content of the entry.
-	 * @param   integer $lifetime  Lifetime of the entry.
+	 * @param   string  $hash       Hash of the entry.
+	 * @param   string  $data       Content of the entry.
+	 * @param   integer $lifetime   Lifetime of the entry.
+	 * @param   bool    $sigDetail  Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime ) {
+	public static function store_item( $hash, $data, $lifetime, $sigDetail ) {
 		/* Empty? */
 		if ( empty( $data ) ) {
 			wp_die( 'MEMCACHE add item: Empty input.' );
@@ -62,7 +63,7 @@ final class Cachify_MEMCACHED {
 		/* Add item */
 		self::$_memcached->set(
 			self::_file_path(),
-			$data . self::_cache_signature(),
+			$data . self::_cache_signature( $sigDetail ),
 			$lifetime
 		);
 	}
@@ -172,15 +173,16 @@ final class Cachify_MEMCACHED {
 	 * Generate signature
 	 *
 	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @change  2.3.0
 	 *
-	 * @return  string  Signature string
+	 * @param   bool $detail  Show details in signature.
+	 * @return  string        Signature string
 	 */
-	private static function _cache_signature() {
+	private static function _cache_signature( $detail ) {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | http://cachify.de',
-			'Memcached',
+			( $detail ? 'Memcached' : __( 'Generated', 'cachify' ) ),
 			date_i18n(
 				'd.m.Y H:i:s',
 				current_time( 'timestamp' )


### PR DESCRIPTION
Addresses issue #108 

Unifies signature in HTML comment and provides the ability to remove additional data.

**Signature with details (old behavior)**
```
<!-- Cachify | http://cachify.de
{METHOD} @ {DATE TIME}
{DETAILS}
-->
```

**Cleaned signature (default)**
```
<!-- Cachify | http://cachify.de
Generated @ {DATE TIME} -->
```