### PR TITLE
Reimplement settings screen output.

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1611,7 +1611,7 @@ final class Cachify {
 	 */
 	public static function options_page() {
 		$options = self::_get_options();
-		$cachify_tabs = self::_get_tabs($options);
+		$cachify_tabs = self::_get_tabs( $options );
 		$current_tab = isset( $_GET['cachify_tab'] ) && isset( $cachify_tabs[ $_GET['cachify_tab'] ] ) ? $_GET['cachify_tab'] : 'settings';
 	?>
 
@@ -1620,7 +1620,7 @@ final class Cachify {
 
 			<?php
 				/* Add a navbar if necessary */
-				if ( count($cachify_tabs) > 1 ) {
+				if ( count( $cachify_tabs ) > 1 ) {
 					echo '<h2 class="nav-tab-wrapper">';
 					foreach ( $cachify_tabs as $tab_key => $tab_data ) {
 						printf(
@@ -1628,16 +1628,16 @@ final class Cachify {
 							$tab_key === $current_tab ? 'nav-tab-active' : '',
 							add_query_arg(
 								array( 'page' => 'cachify', 'cachify_tab' => $tab_key ),
-								admin_url('options-general.php')
+								admin_url( 'options-general.php' )
 							),
-							esc_html($tab_data['name'])
+							esc_html( $tab_data['name'] )
 						);
 					}
 					echo '</h2>';
 				}
 
 				/* Include current tab */
-				include $cachify_tabs[$current_tab]['page'];
+				include $cachify_tabs[ $current_tab ]['page'];
 
 				/* Include common footer */
 				include 'cachify.settings_footer.php';
@@ -1654,7 +1654,7 @@ final class Cachify {
 	 * @param array $options
 	 * @return array
 	 */
-	private static function _get_tabs($options) {
+	private static function _get_tabs( $options ) {
 		/* Settings tab is always present */
 		$tabs = array(
 			'settings' => array(

--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -3,6 +3,8 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 
+<form method="post" action="options.php">
+	<?php settings_fields( 'cachify' ) ?>
 	<table class="form-table">
 		<tr>
 			<th scope="row">
@@ -25,8 +27,8 @@ defined( 'ABSPATH' ) || exit;
 			</th>
 			<td>
 				<label for="cachify_cache_expires">
-					<?php if ( self::METHOD_HDD === $options ['use_apc'] ) : ?>&#8734;
-						<?php else : ?><input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="<?php echo esc_attr( $options ['cache_expires'] ) ?>" class="small-text" />
+					<?php if ( self::METHOD_HDD === $options['use_apc'] ) : ?>&#8734;
+						<?php else : ?><input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="<?php echo esc_attr( $options['cache_expires'] ) ?>" class="small-text" />
 					<?php endif; ?>
 					<?php esc_html_e( 'Hours', 'cachify' ); ?>
 				</label>
@@ -91,16 +93,7 @@ defined( 'ABSPATH' ) || exit;
 				</label>
 			</td>
 		</tr>
-
-		<tr>
-			<th scope="row">
-				<?php submit_button() ?>
-			</th>
-			<td>
-				<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'cachify' ); ?></a>
-				&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/cachify/faq/', 'cachify' ), 'https' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'cachify' ); ?></a>
-				&bull; <a href="https://github.com/pluginkollektiv/cachify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'cachify' ); ?></a>
-				&bull; <a href="https://wordpress.org/support/plugin/cachify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'cachify' ); ?></a>
-			</td>
-		</tr>
 	</table>
+
+	<?php submit_button() ?>
+</form>

--- a/inc/cachify.settings_footer.php
+++ b/inc/cachify.settings_footer.php
@@ -1,0 +1,11 @@
+<?php
+/* Quit */
+defined( 'ABSPATH' ) || exit;
+?>
+
+<p>
+	<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'cachify' ); ?></a>
+	&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/cachify/faq/', 'cachify' ), 'https' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'cachify' ); ?></a>
+	&bull; <a href="https://github.com/pluginkollektiv/cachify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'cachify' ); ?></a>
+	&bull; <a href="https://wordpress.org/support/plugin/cachify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'cachify' ); ?></a>
+</p>

--- a/inc/setup/cachify.apc.htaccess.php
+++ b/inc/setup/cachify.apc.htaccess.php
@@ -29,14 +29,3 @@ $ending = '/cachify/apc/proxy.php
 			WP_PLUGIN_DIR,
 		$ending ); ?></pre>
 	</div>
-
-	<table class="form-table">
-		<tr>
-			<td>
-				<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'cachify' ); ?></a>
-				&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/cachify/faq/', 'cachify' ), 'https' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'cachify' ); ?></a>
-				&bull; <a href="https://github.com/pluginkollektiv/cachify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'cachify' ); ?></a>
-				&bull; <a href="https://wordpress.org/support/plugin/cachify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'cachify' ); ?></a>
-			</td>
-		</tr>
-	</table>

--- a/inc/setup/cachify.apc.nginx.php
+++ b/inc/setup/cachify.apc.nginx.php
@@ -37,14 +37,3 @@ $ending = '/cachify/apc/proxy.php;
 			WP_PLUGIN_DIR,
 		$ending ); ?></pre>
 	</div>
-
-	<table class="form-table">
-		<tr>
-			<td>
-				<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'cachify' ); ?></a>
-				&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/cachify/faq/', 'cachify' ), 'https' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'cachify' ); ?></a>
-				&bull; <a href="https://github.com/pluginkollektiv/cachify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'cachify' ); ?></a>
-				&bull; <a href="https://wordpress.org/support/plugin/cachify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'cachify' ); ?></a>
-			</td>
-		</tr>
-	</table>

--- a/inc/setup/cachify.hdd.htaccess.php
+++ b/inc/setup/cachify.hdd.htaccess.php
@@ -84,14 +84,3 @@ $ending = '/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:C
 			wp_make_link_relative( content_url() ),
 		$ending ); ?></pre>
 	</div>
-
-	<table class="form-table">
-		<tr>
-			<td>
-				<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'cachify' ); ?></a>
-				&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/cachify/faq/', 'cachify' ), 'https' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'cachify' ); ?></a>
-				&bull; <a href="https://github.com/pluginkollektiv/cachify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'cachify' ); ?></a>
-				&bull; <a href="https://wordpress.org/support/plugin/cachify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'cachify' ); ?></a>
-			</td>
-		</tr>
-	</table>

--- a/inc/setup/cachify.hdd.nginx.php
+++ b/inc/setup/cachify.hdd.nginx.php
@@ -66,14 +66,3 @@ location ~ /wp-content/cache {
 	internal;
 }
 </pre></div>
-
-	<table class="form-table">
-		<tr>
-			<td>
-				<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'cachify' ); ?></a>
-				&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/cachify/faq/', 'cachify' ), 'https' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'cachify' ); ?></a>
-				&bull; <a href="https://github.com/pluginkollektiv/cachify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'cachify' ); ?></a>
-				&bull; <a href="https://wordpress.org/support/plugin/cachify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'cachify' ); ?></a>
-			</td>
-		</tr>
-	</table>

--- a/inc/setup/cachify.memcached.nginx.php
+++ b/inc/setup/cachify.memcached.nginx.php
@@ -71,14 +71,3 @@ location @nocache {
 	try_files $uri $uri/ /index.php?$args;
 }
 </pre></div>
-
-	<table class="form-table">
-		<tr>
-			<td>
-				<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'cachify' ); ?></a>
-				&bull; <a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/cachify/faq/', 'cachify' ), 'https' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'cachify' ); ?></a>
-				&bull; <a href="https://github.com/pluginkollektiv/cachify/wiki" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'cachify' ); ?></a>
-				&bull; <a href="https://wordpress.org/support/plugin/cachify" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'cachify' ); ?></a>
-			</td>
-		</tr>
-	</table>


### PR DESCRIPTION
Fixes #110 and by the way:

* Part of `Cachify::options_page()` method has been refactored into separate method: I think it makes sense to keep the logic that determines what tabs are applicable in context of current options separated from the method that renders the options page.
* The "setup" tabs are no longer wrapped in `<form></form>` tags.