### PR TITLE
Skip print_cache() for all requests not routed through main index.php

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1067,7 +1067,7 @@ final class Cachify {
 	 * @return  boolean  TRUE if index
 	 */
 	private static function _is_index() {
-		return basename( $_SERVER['SCRIPT_NAME'] ) !== 'index.php';
+		return basename( $_SERVER['SCRIPT_NAME'] ) === 'index.php';
 	}
 
 	/**
@@ -1117,7 +1117,7 @@ final class Cachify {
 	 * @since   0.2
 	 * @change  2.3.0
 	 *
-	 * @param   boolean..$base_check Check only if request vars are empty and
+	 * @param   boolean  $base_check Check only if request vars are empty and
 	 *                               whether to skip caching for logged users.
 	 * @return  boolean              TRUE on exclusion
 	 *
@@ -1130,6 +1130,11 @@ final class Cachify {
 
 		/* Request vars */
 		if ( ! empty( $_POST ) || ( ! empty( $_GET ) && get_option( 'permalink_structure' ) ) ) {
+			return true;
+		}
+
+		/* Only cache requests routed through main index.php (skip AJAX, WP-Cron, WP-CLI etc.) */
+		if ( ! self::_is_index() ) {
 			return true;
 		}
 
@@ -1149,7 +1154,7 @@ final class Cachify {
 		}
 
 		/* Conditional Tags */
-		if ( self::_is_index() || is_search() || is_404() || is_feed() || is_trackback() || is_robots() || is_preview() || post_password_required() ) {
+		if ( is_search() || is_404() || is_feed() || is_trackback() || is_robots() || is_preview() || post_password_required() ) {
 			return true;
 		}
 


### PR DESCRIPTION
This improves performance of AJAX and WP-CRON requests and compatibility with WP-CLI.

After #93, the `Cachify::print_cache()` runs in `plugins_loaded` hook and thus is executed also in contexts where it cannot succeed (see above). This is unnecessary and can be prevented by running `Cachify::_is_index()` check as early (base) check in `Cachify::_skip_cache()`.

Also, I reverted the comparison in `Cachify::_is_index()` to make method name and phpdoc consistent with what the method does.