### PR TITLE
fix #118 unify parse_url() usage

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -510,13 +510,13 @@ final class Cachify {
 			return $data;
 		}
 
-		/* Path */
-		$path = wp_parse_url( site_url(), PHP_URL_PATH );
+		/* Parse site URL */
+		$url_parts = wp_parse_url( site_url() );
 
 		/* Output */
 		$data .= sprintf(
 			'%2$sDisallow: %1$s/wp-content/cache/cachify/%2$s',
-			( empty( $path ) ? '' : $path ),
+			( empty( $url_parts['path'] ) ? '' : $url_parts['path'] ),
 			PHP_EOL
 		);
 
@@ -1040,8 +1040,9 @@ final class Cachify {
 	 */
 	private static function _cache_hash( $url = '' ) {
 		$prefix = is_ssl() ? 'https-' : '';
+		$url_parts = wp_parse_url( $url );
 		return md5(
-			empty( $url ) ? ( $prefix . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) : ( $prefix . wp_parse_url( $url, PHP_URL_HOST ) . wp_parse_url( $url, PHP_URL_PATH ) )
+			empty( $url ) ? ( $prefix . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) : ( $prefix . $url_parts['host'] . $url_parts['path'] )
 		) . '.cachify';
 	}
 

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -303,19 +303,16 @@ final class Cachify_HDD {
 	private static function _file_path( $path = null ) {
 		$prefix = is_ssl() ? 'https-' : '';
 
+		$host_parts = wp_parse_url( 'http://' . strtolower( $_SERVER['HTTP_HOST'] ) );
+		$path_parts = wp_parse_url( $path ? $path : $_SERVER['REQUEST_URI'] );
+
 		$path = sprintf(
 			'%s%s%s%s%s',
 			CACHIFY_CACHE_DIR,
 			DIRECTORY_SEPARATOR,
 			$prefix,
-			parse_url(
-				'http://' . strtolower( $_SERVER['HTTP_HOST'] ),
-				PHP_URL_HOST
-			),
-			parse_url(
-				( $path ? $path : $_SERVER['REQUEST_URI'] ),
-				PHP_URL_PATH
-			)
+			$host_parts['host'],
+			$path_parts['path']
 		);
 
 		if ( validate_file( $path ) > 0 ) {

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -303,7 +303,6 @@ final class Cachify_HDD {
 	private static function _file_path( $path = null ) {
 		$prefix = is_ssl() ? 'https-' : '';
 
-		$host_parts = wp_parse_url( 'http://' . strtolower( $_SERVER['HTTP_HOST'] ) );
 		$path_parts = wp_parse_url( $path ? $path : $_SERVER['REQUEST_URI'] );
 
 		$path = sprintf(
@@ -311,7 +310,7 @@ final class Cachify_HDD {
 			CACHIFY_CACHE_DIR,
 			DIRECTORY_SEPARATOR,
 			$prefix,
-			$host_parts['host'],
+			strtolower( $_SERVER['HTTP_HOST'] ),
 			$path_parts['path']
 		);
 

--- a/inc/cachify_memcached.class.php
+++ b/inc/cachify_memcached.class.php
@@ -200,14 +200,13 @@ final class Cachify_MEMCACHED {
 	 * @return  string        Path to cache file
 	 */
 	private static function _file_path( $path = null ) {
+		$path_parts = wp_parse_url( $path ? $path : $_SERVER['REQUEST_URI'] );
+
 		return trailingslashit(
 			sprintf(
 				'%s%s',
 				$_SERVER['HTTP_HOST'],
-				parse_url(
-					( $path ? $path : $_SERVER['REQUEST_URI'] ),
-					PHP_URL_PATH
-				)
+				$path_parts['path']
 			)
 		);
 	}


### PR DESCRIPTION
Quick fix for #118.

* remove the `$component` parameter from `wp_parse_url()` calls, as it's not supported < 4.7
* replace every `parse_url()` call with `wp_parse_url()` (4.4 compatible)