### PR TITLE
Do not wp_die() on I/O errors.

### DIFF
--- a/inc/cachify_apc.class.php
+++ b/inc/cachify_apc.class.php
@@ -41,9 +41,10 @@ final class Cachify_APC {
 	 * @param   bool    $sig_detail  Show details in signature.
 	 */
 	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
-		/* Empty? */
-		if ( empty( $hash ) || empty( $data ) ) {
-			wp_die( 'APC add item: Empty input.' );
+		/* Do not store empty data. */
+		if ( empty( $data ) ) {
+			trigger_error( __METHOD__ . ": Empty input.", E_USER_WARNING );
+			return;
 		}
 
 		/* Store */
@@ -64,11 +65,6 @@ final class Cachify_APC {
 	 * @return  mixed         Content of the entry
 	 */
 	public static function get_item( $hash ) {
-		/* Empty? */
-		if ( empty( $hash ) ) {
-			wp_die( 'APC get item: Empty input.' );
-		}
-
 		return ( function_exists( 'apc_exists' ) ? apc_exists( $hash ) : apc_fetch( $hash ) );
 	}
 
@@ -82,12 +78,6 @@ final class Cachify_APC {
 	 * @param   string $url   URL of the entry [optional].
 	 */
 	public static function delete_item( $hash, $url = '' ) {
-		/* Empty? */
-		if ( empty( $hash ) ) {
-			wp_die( 'APC delete item: Empty input.' );
-		}
-
-		/* Delete */
 		apc_delete( $hash );
 	}
 

--- a/inc/cachify_db.class.php
+++ b/inc/cachify_db.class.php
@@ -40,9 +40,10 @@ final class Cachify_DB {
 	 * @param   integer $lifetime  Lifetime of the entry.
 	 */
 	public static function store_item( $hash, $data, $lifetime ) {
-		/* Empty? */
-		if ( empty( $hash ) || empty( $data ) ) {
-			wp_die( 'DB add item: Empty input.' );
+		/* Do not store empty data. */
+		if ( empty( $data ) ) {
+			trigger_error( __METHOD__ . ": Empty input.", E_USER_WARNING );
+			return;
 		}
 
 		/* Store */
@@ -71,11 +72,6 @@ final class Cachify_DB {
 	 * @return  mixed           Content of the entry
 	 */
 	public static function get_item( $hash ) {
-		/* Empty? */
-		if ( empty( $hash ) ) {
-			wp_die( 'DB get item: Empty input.' );
-		}
-
 		return get_transient( $hash );
 	}
 
@@ -89,12 +85,6 @@ final class Cachify_DB {
 	 * @param   string $url   URL of the entry [optional].
 	 */
 	public static function delete_item( $hash, $url = '' ) {
-		/* Empty? */
-		if ( empty( $hash ) ) {
-			wp_die( 'DB delete item: Empty input.' );
-		}
-
-		/* Delete */
 		delete_transient( $hash );
 	}
 

--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -35,15 +35,16 @@ final class Cachify_HDD {
 	 * @since   2.0
 	 * @change  2.3.0
 	 *
-	 * @param   string  $hash        Hash  of the entry [optional].
+	 * @param   string  $hash        Hash  of the entry [ignored].
 	 * @param   string  $data        Content of the entry.
-	 * @param   integer $lifetime    Lifetime of the entry [optional].
+	 * @param   integer $lifetime    Lifetime of the entry [ignored].
 	 * @param   bool    $sig_detail  Show details in signature.
 	 */
 	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
-		/* Empty? */
+		/* Do not store empty data. */
 		if ( empty( $data ) ) {
-			wp_die( 'HDD add item: Empty input.' );
+			trigger_error( __METHOD__ . ": Empty input.", E_USER_WARNING );
+			return;
 		}
 
 		/* Store data */
@@ -72,16 +73,10 @@ final class Cachify_HDD {
 	 * @since   2.0
 	 * @change  2.0
 	 *
-	 * @param   string $hash  Hash of the entry [optional].
+	 * @param   string $hash  Hash of the entry [ignored].
 	 * @param   string $url   URL of the entry.
 	 */
-	public static function delete_item( $hash = '', $url ) {
-		/* Empty? */
-		if ( empty( $url ) ) {
-			wp_die( 'HDD delete item: Empty input.' );
-		}
-
-		/* Delete */
+	public static function delete_item( $hash, $url ) {
 		self::_clear_dir(
 			self::_file_path( $url )
 		);
@@ -157,14 +152,17 @@ final class Cachify_HDD {
 	 * @param   string $data  Cache content.
 	 */
 	private static function _create_files( $data ) {
+		$file_path = self::_file_path();
+
 		/* Create directory */
-		if ( ! wp_mkdir_p( self::_file_path() ) ) {
-			wp_die( 'Unable to create directory.' );
+		if ( ! wp_mkdir_p( $file_path ) ) {
+			trigger_error( __METHOD__ . ": Unable to create directory {$file_path}.", E_USER_WARNING );
+			return;
 		}
 
 		/* Write to file */
-		self::_create_file( self::_file_html(), $data );
-		self::_create_file( self::_file_gzip(), gzencode( $data, 9 ) );
+		self::_create_file( self::_file_html( $file_path ), $data );
+		self::_create_file( self::_file_gzip( $file_path ), gzencode( $data, 9 ) );
 	}
 
 	/**
@@ -179,7 +177,8 @@ final class Cachify_HDD {
 	private static function _create_file( $file, $data ) {
 		/* Writable? */
 		if ( ! $handle = @fopen( $file, 'wb' ) ) {
-			wp_die( 'Could not write file.' );
+			trigger_error( __METHOD__ . ": Could not write file {$file}.", E_USER_WARNING );
+			return;
 		}
 
 		/* Write */
@@ -329,23 +328,25 @@ final class Cachify_HDD {
 	 * Path to HTML file
 	 *
 	 * @since   2.0
-	 * @change  2.0
+	 * @change  2.3.0
 	 *
-	 * @return  string  Path to HTML file
+	 * @param   string $file_path   File path [optional].
+	 * @return  string              Path to HTML file
 	 */
-	private static function _file_html() {
-		return self::_file_path() . 'index.html';
+	private static function _file_html( $file_path = '' ) {
+		return ( empty( $file_path ) ? self::_file_path() : $file_path ) . 'index.html';
 	}
 
 	/**
 	 * Path to GZIP file
 	 *
 	 * @since   2.0
-	 * @change  2.0
+	 * @change  2.3.0
 	 *
-	 * @return  string  Path to GZIP file
+	 * @param   string $file_path   File path [optional].
+	 * @return  string              Path to GZIP file
 	 */
-	private static function _file_gzip() {
-		return self::_file_path() . 'index.html.gz';
+	private static function _file_gzip( $file_path = '' ) {
+		return ( empty( $file_path ) ? self::_file_path() : $file_path )  . 'index.html.gz';
 	}
 }

--- a/inc/cachify_memcached.class.php
+++ b/inc/cachify_memcached.class.php
@@ -44,15 +44,16 @@ final class Cachify_MEMCACHED {
 	 * @since   2.0.7
 	 * @change  2.3.0
 	 *
-	 * @param   string  $hash       Hash of the entry.
+	 * @param   string  $hash       Hash of the entry [ignored].
 	 * @param   string  $data       Content of the entry.
 	 * @param   integer $lifetime   Lifetime of the entry.
 	 * @param   bool    $sigDetail  Show details in signature.
 	 */
 	public static function store_item( $hash, $data, $lifetime, $sigDetail ) {
-		/* Empty? */
+		/* Do not store empty data. */
 		if ( empty( $data ) ) {
-			wp_die( 'MEMCACHE add item: Empty input.' );
+			trigger_error( __METHOD__ . ": Empty input.", E_USER_WARNING );
+			return;
 		}
 
 		/* Server connect */
@@ -147,7 +148,7 @@ final class Cachify_MEMCACHED {
 	public static function get_stats() {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
-			wp_die( 'MEMCACHE: Not enabled.' );
+			return null;
 		}
 
 		/* Info */


### PR DESCRIPTION
Fixes #106:

1. I think we can assume that `$hash` and `$url` arguments are correctly provided and do not check them with `empty()`.
1. Warnings are triggered via [trigger_error](http://at2.php.net/manual/en/function.trigger-error.php) in several places.
1. I left only [single instance](https://github.com/pluginkollektiv/cachify/blob/master/inc/cachify_hdd.class.php#L321-L323) of `wp_die()` in `_file_path()` method. It can only be called when there is either "./" or ".." in URL which means that someone is trying something nasty. I don't think any sane website would have "./" or ".." in front-end URLs, so I consider use of `wp_die()` as appropriate here.