### PR TITLE
Make sure only files of the current blog can be deleted (Fixes #23)

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -731,7 +731,7 @@ final class Cachify {
 		}
 
 		/* Flush cache */
-		if ( is_multisite() && is_network_admin() && is_plugin_active_for_network( CACHIFY_BASE ) ) {
+		if ( is_multisite() && is_network_admin() ) {
 			/* Old blog */
 			$old = $GLOBALS['wpdb']->blogid;
 

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -730,48 +730,19 @@ final class Cachify {
 			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		}
 
-		/* Multisite & Network */
-		if ( is_multisite() && is_plugin_active_for_network( CACHIFY_BASE ) ) {
-			/* Old blog */
-			$old = $GLOBALS['wpdb']->blogid;
+		/* Flush cache */
+		self::flush_total_cache();
 
-			/* Blog IDs */
-			$ids = self::_get_blog_ids();
-
-			/* Loop over blogs */
-			foreach ( $ids as $id ) {
-				switch_to_blog( $id );
-				self::flush_total_cache();
-			}
-
-			/* Switch back to old blog */
-			switch_to_blog( $old );
-
-			/* Notice */
-			if ( is_admin() ) {
-				add_action(
-					'network_admin_notices',
-					array(
-						__CLASS__,
-						'flush_notice',
-					)
-				);
-			}
-		} else {
-			/* Flush cache */
-			self::flush_total_cache();
-
-			/* Notice */
-			if ( is_admin() ) {
-				add_action(
-					'admin_notices',
-					array(
-						__CLASS__,
-						'flush_notice',
-					)
-				);
-			}
-		}// End if().
+		/* Notice */
+		if ( is_admin() ) {
+			add_action(
+				'admin_notices',
+				array(
+					__CLASS__,
+					'flush_notice',
+				)
+			);
+		}
 
 		if ( ! is_admin() ) {
 			wp_safe_redirect(

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -731,19 +731,46 @@ final class Cachify {
 		}
 
 		/* Flush cache */
-		self::flush_total_cache();
+		if ( is_multisite() && is_network_admin() && is_plugin_active_for_network( CACHIFY_BASE ) ) {
+			/* Old blog */
+			$old = $GLOBALS['wpdb']->blogid;
 
-		/* Notice */
-		if ( is_admin() ) {
-			add_action(
-				'admin_notices',
-				array(
-					__CLASS__,
-					'flush_notice',
-				)
-			);
+			/* Blog IDs */
+			$ids = self::_get_blog_ids();
+
+			/* Loop over blogs */
+			foreach ( $ids as $id ) {
+				switch_to_blog( $id );
+				self::flush_total_cache();
+			}
+
+			/* Switch back to old blog */
+			switch_to_blog( $old );
+
+			/* Notice */
+			if ( is_admin() ) {
+				add_action(
+					'network_admin_notices',
+					array(
+						__CLASS__,
+						'flush_notice',
+					)
+				);
+			}
+		} else {
+			self::flush_total_cache();
+
+			/* Notice */
+			if ( is_admin() ) {
+				add_action(
+					'admin_notices',
+					array(
+						__CLASS__,
+						'flush_notice',
+					)
+				);
+			}
 		}
-
 		if ( ! is_admin() ) {
 			wp_safe_redirect(
 				remove_query_arg(


### PR DESCRIPTION
Flushing the HDD cache deleted all files in the cache. On a multisite this would mean the administrator of blog 1 was also able to delete the cache of blog 2.

The new behavior:
* If you click in the network admin on flush all files get deleted.
* If you click on a blog on flush, it checkes, whether the file belongs to the blog or not. If not, it won't get deleted.

DB is basically not affacted as the data is stored in the `options` table and so different from blog to blog. APC and Memcache, from my understanding, we can't flush only specific parts of the cache.

_Sitenote_: Actually, it was the intended behavior of the plugin in case the plugin was activated network wide. For me: Only because the plugin is network wide activated shouldnt give a blog admin the power to delete the cache of the whole network.

I think this needs intensive testing and some evaluation, but I think it fixes #23 