### PR TITLE
Fix hash function for APC proxy

### DIFF
--- a/apc/proxy.php
+++ b/apc/proxy.php
@@ -9,12 +9,35 @@ if ( ! empty( $_COOKIE ) ) {
 	}
 }
 
+/**
+ * Determines if SSL is used.
+ *
+ * @see is_ssl() (wp-includes/load.php).
+ *
+ * @return bool True if SSL, otherwise false.
+ */
+function cachify_is_ssl() {
+	if ( isset( $_SERVER['HTTPS'] ) ) {
+		if ( 'on' == strtolower( $_SERVER['HTTPS'] ) ) {
+			return true;
+		}
+
+		if ( '1' == $_SERVER['HTTPS'] ) {
+			return true;
+		}
+	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
+		return true;
+	}
+
+	return false;
+}
+
 if (
 	empty( $_cachify_logged_in )
 	&& ( strpos( filter_input( INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_STRING ), '/wp-admin/' ) === false )
 	&& ( strpos( filter_input( INPUT_SERVER, 'HTTP_ACCEPT_ENCODING', FILTER_SANITIZE_STRING ), 'gzip' ) !== false )
 	&& extension_loaded( 'apc' )
-	&& ( $cache = apc_fetch( md5( $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) . '.cachify' ) )
+	&& ( $cache = apc_fetch( md5( ( cachify_is_ssl() ? 'https-' : '' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) . '.cachify' ) )
 ) {
 	ini_set( 'zlib.output_compression', 'Off' );
 

--- a/apc/proxy.php
+++ b/apc/proxy.php
@@ -18,14 +18,14 @@ if ( ! empty( $_COOKIE ) ) {
  */
 function cachify_is_ssl() {
 	if ( isset( $_SERVER['HTTPS'] ) ) {
-		if ( 'on' == strtolower( $_SERVER['HTTPS'] ) ) {
+		if ( 'on' === strtolower( $_SERVER['HTTPS'] ) ) {
 			return true;
 		}
 
-		if ( '1' == $_SERVER['HTTPS'] ) {
+		if ( '1' === $_SERVER['HTTPS'] ) {
 			return true;
 		}
-	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
+	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' === $_SERVER['SERVER_PORT'] ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
The added prefix for HTTPS pages, introduced in #2, has not been added for the APC proxy which breaks APC functionallity for HTTPS pages (reported in #135).

Just copied the `is_ssl()` from WP to be consistent and adapted the hash function. Didn't test though...