### PR TITLE
Flush Cachify cache when post is deleted directly.

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -124,6 +124,14 @@ final class Cachify {
 		);
 
 		add_action(
+			'before_delete_post',
+			array(
+				__CLASS__,
+				'flush_total_cache',
+			)
+		);
+
+		add_action(
 			'wp_trash_post',
 			array(
 				__CLASS__,


### PR DESCRIPTION
I just came upon an issue when Cachify cache has not been flushed when posts have been deleted from website. I found out that Cachify only flush cache when [wp_trash_post()](https://developer.wordpress.org/reference/functions/wp_trash_post/) is called, but not when [wp_delete_post()](https://developer.wordpress.org/reference/functions/wp_delete_post/) is called directly.

Also, when `EMPTY_TRASH_DAYS` constant is set to 0 (= trash is disabled), `wp_trash_post()` calls `wp_delete_post()` without running `wp_trash_post` action.

There are several actions fired in `wp_delete_post()`, I picked up `before_delete_post` just because `wp_trash_post` action, to which Cachify hooks already, is also fired before the post is actually trashed.