### PR TITLE
Allow HDD cache to be cleared when cachify_user_can_flush_cache filter returns true for current user.

### DIFF
--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -363,7 +363,7 @@ final class Cachify_HDD {
 			return false;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! apply_filters( 'cachify_user_can_flush_cache', current_user_can( 'manage_options' ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
I want all users to be able to clear Cachify cache, so I'm using the following hook:
```php
add_filter('cachify_user_can_flush_cache', '__return_true');
```

Clear cache icon is shown, admin notice says cache is cleared, but no files get deleted from disk. The problem is that there's an extra check done before any file gets physically deleted and it has not been filtered.