### PR TITLE
Allow HDD cache to be flushed also when current user is not an admin.

### DIFF
--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -363,10 +363,6 @@ final class Cachify_HDD {
 			return false;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
-		}
-
 		if ( 0 !== strpos( $file, CACHIFY_CACHE_DIR ) ) {
 			return false;
 		}


### PR DESCRIPTION
I think the `current_user_can( 'manage_options' )` check in `_user_can_delete()` method has been introduced by mistake, it effectively breaks HDD cache flushing for any non-admin user.