### PR TITLE
Minor correction for compatibility with PHP 5.2

### DIFF
--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -14,7 +14,8 @@ final class Cachify_HDD {
 	 * @return  boolean  true/false  TRUE when installed
 	 */
 	public static function is_available() {
-		return ! empty( get_option( 'permalink_structure' ) );
+		$option = get_option( 'permalink_structure' );
+		return ! empty( $option );
 	}
 
 	/**


### PR DESCRIPTION
Passing method call to empty() is not available in PHP prior to 5.5, so add temporary local variable to restore compatibility.

I know, 5.2 is damn old and there are plenty of reasons to go for >5.5, so we might also raise requiremed version to 5.5, but a single line does the job and it only affects one caching method...