### PR TITLE
Patch 2

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1302,14 +1302,13 @@ final class Cachify {
 	 * @return  string        Content of the page.
 	 */
 	public static function set_cache( $data ) {
-
 		/* Empty? */
 		if ( empty( $data ) ) {
 			return '';
 		}
 
 		/**
-		 * Filters wether the buffered data should actually be cached
+		 * Filters whether the buffered data should actually be cached
 		 *
 		 * @param bool   $should_cache  Whether the data should be cached.
 		 * @param string $data          The actual data.

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1303,12 +1303,21 @@ final class Cachify {
 	 */
 	public static function set_cache( $data ) {
 
-		$should_cache = apply_filters( 'cachify_store_item', true, $data, self::$method, self::_cache_hash(), self::_cache_expires() );
-
 		/* Empty? */
 		if ( empty( $data ) ) {
 			return '';
 		}
+
+		/**
+		 * Filters wether the buffered data should actually be cached
+		 *
+		 * @param bool   $should_cache  Whether the data should be cached.
+		 * @param string $data          The actual data.
+		 * @param string $method        The selected caching method.
+		 * @param string $cache_hash    The cache hash.
+		 * @param int    $cache_expires Cache validity period.
+		 */
+		$should_cache = apply_filters( 'cachify_store_item', true, $data, self::$method, self::_cache_hash(), self::_cache_expires() );
 
 		/* Save? */
 		if ( $should_cache ) {

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1302,22 +1302,27 @@ final class Cachify {
 	 * @return  string        Content of the page.
 	 */
 	public static function set_cache( $data ) {
+
+		$should_cache = apply_filters( 'cachify_store_item', true, $data, self::$method, self::_cache_hash(), self::_cache_expires() );
+
 		/* Empty? */
 		if ( empty( $data ) ) {
 			return '';
 		}
 
-		/* Save */
-		call_user_func(
-			array(
-				self::$method,
-				'store_item',
-			),
-			self::_cache_hash(),
-			self::_minify_cache( $data ),
-			self::_cache_expires(),
-			self::_signature_details()
-		);
+		/* Save? */
+		if ( $should_cache ) {
+			call_user_func(
+				array(
+					self::$method,
+					'store_item',
+				),
+				self::_cache_hash(),
+				self::_minify_cache( $data ),
+				self::_cache_expires(),
+				self::_signature_details()
+			);
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
Currently there is no way to decide against caching a given page after the `template_redirect` action has fired.  
This pull adds a filter `cachify_store_item` which fires before the actual `store_item` function of the selected caching method is called.  

This would allow developers to decide against caching a page at any point in the rendering process.  
The simplest way to achieve this would be adding `add_filter( 'cachify_store_item', '__return_false' );` anywhere in the codepath.

Examples for this would be HDD-cache in conjunction with a page that uses a nonce. The nonce would break after 24 hours if the cache isn't manually flushed.

Another example could be a page with dynamic sections that should not be cached but are not yet available at the time `template_redirect` fires.