### PR TITLE
Add description text on how to flush the cache manually

### DIFF
--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -34,8 +34,8 @@ defined( 'ABSPATH' ) || exit;
 				
 				<p class="description">
 					<?php printf(
-						/* translators: Placeholder is the icon itself as dashicon */
-						esc_html__( 'Flush the cache by clicking the button below or the %1$s icon in the admin bar.', 'rh-50' ),
+						/* translators: Placeholder is the trash icon itself as dashicon */
+						esc_html__( 'Flush the cache by clicking the button below or the %1$s icon in the admin bar.', 'cachify' ),
 						'<span class="dashicons dashicons-trash" aria-hidden="true"></span><span class="screen-reader-text">"' . esc_html__( 'Flush the cachify cache', 'cachify' ) . '"</span>'
 					); ?>
 				</p>

--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -32,7 +32,13 @@ defined( 'ABSPATH' ) || exit;
 					<?php esc_html_e( 'Hours', 'cachify' ); ?>
 				<?php endif; ?>
 				
-				<br />
+				<p class="description">
+					<?php printf(
+						/* translators: Placeholder is the icon itself as dashicon */
+						esc_html__( 'Flush the cache by clicking the button below or the %1$s icon in the admin bar.', 'rh-50' ),
+						'<span class="dashicons dashicons-trash" aria-hidden="true"></span><span class="screen-reader-text">"' . esc_html__( 'Flush the cachify cache', 'cachify' ) . '"</span>'
+					); ?>
+				</p>
 				
 				<p><a class="button button-flush" href="<?php echo wp_nonce_url( add_query_arg( '_cachify', 'flush' ), '_cachify__flush_nonce' ); ?>"><?php esc_html_e( 'Flush cache now', 'cachify' )  ?></a></p>
 			</td>


### PR DESCRIPTION
As mentioned in PR https://github.com/pluginkollektiv/cachify/pull/150#issuecomment-363343499 by @krafit, it would be a good way to add a description text in the **Cache expiration** section under the input. I created this PR as suggestion, it would look like this (in database and in HDD cache mode):

**Database cache mode:**
![description-database-cache](https://user-images.githubusercontent.com/12687777/45823999-3e1b9200-bcef-11e8-8fa6-1335e871d0bc.png)
**HDD cache mode:**
![description-harddisk-cache](https://user-images.githubusercontent.com/12687777/45824003-3e1b9200-bcef-11e8-86e2-4786d497574f.png)

See: #151 