### PR TITLE
Admin bar icon – Add option to show text caption next to flush cache icon.

### DIFF
--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -499,6 +499,7 @@ final class Cachify {
 				'use_apc'		 	=> self::METHOD_DB,
 				'reset_on_comment'  => 0,
 				'sig_detail'        => 0,
+				'show_adminbar_button_caption' => false
 			)
 		);
 	}
@@ -691,7 +692,11 @@ final class Cachify {
 		}
 
 		/* Display the admin icon anytime */
-		echo '<style>#wp-admin-bar-cachify{display:list-item !important} #wp-admin-bar-cachify .ab-icon{margin:0 !important} #wp-admin-bar-cachify .ab-icon:before{content:"\f182";top:2px;margin:0}</style>';
+		echo '<style>#wp-admin-bar-cachify{display:list-item !important} #wp-admin-bar-cachify .ab-icon{margin:0 !important} #wp-admin-bar-cachify .ab-icon:before{content:"\f182";top:2px;margin:0;} #wp-admin-bar-cachify .ab-label{margin:0 5px}</style>';
+
+		/* Get setting whether to show caption next to icon */
+		$options = self::_get_options();
+		$show_adminbar_button_caption = $options['show_adminbar_button_caption'];
 
 		/* Add menu item */
 		$wp_admin_bar->add_menu(
@@ -699,7 +704,17 @@ final class Cachify {
 				'id' 	 => 'cachify',
 				'href'   => wp_nonce_url( add_query_arg( '_cachify', 'flush' ), '_cachify__flush_nonce' ), // esc_url in /wp-includes/class-wp-admin-bar.php#L438.
 				'parent' => 'top-secondary',
-				'title'	 => '<span class="ab-icon dashicons"></span>',
+				'title'	 => '<span class="ab-icon dashicons"></span>' . (
+											( $show_adminbar_button_caption ) ?
+												'<span class="ab-label">' .
+												_x(
+													'Flush site cache',
+													'Flush site cache caption in admin bar, next to icon, if activated in settings.',
+													'cachify'
+												) .
+												'</span>'
+											: ''
+										),
 				'meta'   => array(
 					'title' => esc_html__( 'Flush the cachify cache', 'cachify' ),
 				),
@@ -1417,7 +1432,7 @@ final class Cachify {
 					true
 				);
 			break;
-			
+
 			case 'settings_page_cachify':
 				wp_enqueue_style(
 					'cachify-settings',
@@ -1430,7 +1445,7 @@ final class Cachify {
 			default:
 			break;
 		}
-		
+
 	}
 
 	/**
@@ -1640,14 +1655,15 @@ final class Cachify {
 
 		/* Return */
 		return array(
-			'only_guests'      => (int) ( ! empty( $data['only_guests'] )),
-			'compress_html'    => (int) $data['compress_html'],
-			'cache_expires'    => (int) ( isset( $data['cache_expires'] ) ? $data['cache_expires'] : self::$options['cache_expires'] ),
-			'without_ids'      => (string) isset( $data['without_ids'] ) ? sanitize_text_field( $data['without_ids'] ) : '',
-			'without_agents'   => (string) isset( $data['without_agents'] ) ? sanitize_text_field( $data['without_agents'] ) : '',
-			'use_apc'          => (int) $data['use_apc'],
-			'reset_on_comment' => (int) ( ! empty( $data['reset_on_comment'] )),
-			'sig_detail'       => (int) ( ! empty( $data['sig_detail'] )),
+			'only_guests'      							=> (int) ( ! empty( $data['only_guests'] )),
+			'compress_html'   	 						=> (int) $data['compress_html'],
+			'cache_expires'    							=> (int) ( isset( $data['cache_expires'] ) ? $data['cache_expires'] : self::$options['cache_expires'] ),
+			'without_ids'      							=> (string) isset( $data['without_ids'] ) ? sanitize_text_field( $data['without_ids'] ) : '',
+			'without_agents'   							=> (string) isset( $data['without_agents'] ) ? sanitize_text_field( $data['without_agents'] ) : '',
+			'use_apc'          							=> (int) $data['use_apc'],
+			'reset_on_comment' 							=> (int) ( ! empty( $data['reset_on_comment'] )),
+			'sig_detail'       							=> (int) ( ! empty( $data['sig_detail'] )),
+			'show_adminbar_button_caption' 	=> (int) ( ! empty( $data['show_adminbar_button_caption'] )),
 		);
 	}
 

--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -31,16 +31,36 @@ defined( 'ABSPATH' ) || exit;
 					<input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="<?php echo esc_attr( $options['cache_expires'] ) ?>" class="small-text" />
 					<?php esc_html_e( 'Hours', 'cachify' ); ?>
 				<?php endif; ?>
-				
+
+				<p>
+					<label for="cachify_show_adminbar_button_caption">
+						<input type="checkbox" name="cachify[show_adminbar_button_caption]" id="cachify_show_adminbar_button_caption" value="1" <?php checked( '1', $options['show_adminbar_button_caption'] ); ?> />
+						<?php printf(
+							/* translators: Placeholder is the trash icon itself as dashicon */
+							esc_html__(
+								'Show text caption next to the %1$s icon in the admin bar.',
+								'Placeholder is the trash icon itself as dashicon',
+								'cachify'
+							),
+							'<span class="dashicons dashicons-trash" aria-hidden="true"></span><span class="screen-reader-text">"' . esc_html__( 'Example of icon for button to flush the cachify cache', 'cachify' ) . '"</span>'
+						); ?>
+					</label>
+				</p>
+
 				<p class="description">
 					<?php printf(
 						/* translators: Placeholder is the trash icon itself as dashicon */
-						esc_html__( 'Flush the cache by clicking the button below or the %1$s icon in the admin bar.', 'cachify' ),
-						'<span class="dashicons dashicons-trash" aria-hidden="true"></span><span class="screen-reader-text">"' . esc_html__( 'Flush the cachify cache', 'cachify' ) . '"</span>'
+						esc_html_x(
+							'Flush the cache by clicking the button below or the %1$s icon in the admin bar.',
+							'Placeholder is the trash icon itself as dashicon',
+							'cachify'
+						),
+						'<span class="dashicons dashicons-trash" aria-hidden="true"></span><span class="screen-reader-text">"' . esc_html__( 'Example of icon for button to flush the cachify cache', 'cachify' ) . '"</span>'
 					); ?>
 				</p>
-				
+
 				<p><a class="button button-flush" href="<?php echo wp_nonce_url( add_query_arg( '_cachify', 'flush' ), '_cachify__flush_nonce' ); ?>"><?php esc_html_e( 'Flush cache now', 'cachify' )  ?></a></p>
+
 			</td>
 		</tr>
 


### PR DESCRIPTION
Addresses UX problem described in #151.

### Behavior
- By default flush cache button in admin bar looks the same as always
- There is a new option right above the new flush cache button on the settings page that enables  the caption (for admins who fear their users/co-workers will miss the button)
- When the setting is true a text caption will be shown next to the icon inside the button within the admin bar

**Note:** If you have any suggestions regarding functionality, wording or code style, I'd be happy to discuss. This is my first PR in this repository.

### Screenshots
<img width="197" alt="bildschirmfoto 2018-10-07 um 19 55 24" src="https://user-images.githubusercontent.com/4127167/46585060-055c1680-ca6c-11e8-9785-17051714f96c.png">
<img width="801" alt="bildschirmfoto 2018-10-07 um 19 55 16" src="https://user-images.githubusercontent.com/4127167/46585061-055c1680-ca6c-11e8-98a8-b3166a28e5a4.png">
