### PR TITLE
CLI Commands for Cachify

### DIFF
--- a/cachify.php
+++ b/cachify.php
@@ -72,13 +72,21 @@ register_uninstall_hook(
 	)
 );
 
+/* WP-CLI */
+add_action(
+    'init',
+    array(
+        'Cachify_CLI',
+        'add_commands'
+    )
+);
 
 /* Autoload Init */
 spl_autoload_register( 'cachify_autoload' );
 
 /* Autoload function */
 function cachify_autoload( $class ) {
-	if ( in_array( $class, array( 'Cachify', 'Cachify_APC', 'Cachify_DB', 'Cachify_HDD', 'Cachify_MEMCACHED' ) ) ) {
+	if ( in_array( $class, array( 'Cachify', 'Cachify_APC', 'Cachify_DB', 'Cachify_HDD', 'Cachify_MEMCACHED', 'Cachify_CLI' ) ) ) {
 		require_once(
 			sprintf(
 				'%s/inc/%s.class.php',

--- a/inc/cachify_cli.class.php
+++ b/inc/cachify_cli.class.php
@@ -60,7 +60,6 @@ final class Cachify_CLI {
    */
   public static function add_commands() {
     if ( defined( 'WP_CLI' ) && WP_CLI ) {
-      $cmd_optimize = function( $args, $assoc_args ) { self::optimize( $args, $assoc_args ); };
 
       /*
        * Add flush command

--- a/inc/cachify_cli.class.php
+++ b/inc/cachify_cli.class.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+* Cachify_CLI
+*/
+final class Cachify_CLI {
+
+  public static function flush_cache( $args, $assoc_args ){
+
+    $assoc_args = wp_parse_args( $assoc_args, array( 'all-methods' => false ) );
+
+    $all_methods = boolval( $assoc_args[ 'all-methods' ] );
+
+    Cachify::flush_total_cache( $all_methods );
+
+    WP_CLI::success( "Cache flushed" );
+
+  }
+
+  public static function add_commands() {
+    if ( defined( 'WP_CLI' ) && WP_CLI ) {
+      $cmd_optimize = function( $args, $assoc_args ) { self::optimize( $args, $assoc_args ); };
+      WP_CLI::add_command(
+        'cachify flush',
+        array(
+          'Cachify_CLI',
+          'flush_cache',
+        ),
+        array(
+            'shortdesc' => 'Flush site cache',
+            'synopsis'  => array(
+                array(
+                    'type'     => 'flag',
+                    'name'     => 'all-methods',
+                    'optional' => true,
+                ),
+            ),
+        )
+      );
+    }
+  }
+}

--- a/inc/cachify_cli.class.php
+++ b/inc/cachify_cli.class.php
@@ -5,21 +5,86 @@
 */
 final class Cachify_CLI {
 
+  /**
+	 * Flush Cache
+	 *
+	 * @since   2.3.0
+	 * @change  2.3.0
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
   public static function flush_cache( $args, $assoc_args ){
 
-    $assoc_args = wp_parse_args( $assoc_args, array( 'all-methods' => false ) );
+    // set default args
+    $assoc_args = wp_parse_args( $assoc_args, array( 'all-methods' => false, 'ids' => null, 'page-url' => null ) );
 
-    $all_methods = boolval( $assoc_args[ 'all-methods' ] );
+    if( $assoc_args['ids'] ){
 
-    Cachify::flush_total_cache( $all_methods );
+      // convert id list to array
+      $ids = explode( ',', $assoc_args['ids'] );
+
+      foreach ( $ids as $id ) {
+        Cachify::remove_page_cache_by_post_id( $id );
+        WP_CLI::line( 'Cache flushed for ID ' . $id );
+      }
+
+    }elseif ( $assoc_args['page-url'] ) {
+
+      Cachify::remove_page_cache_by_url( $assoc_args['page-url'] );
+      WP_CLI::line( 'Cache flushed for URL ' . $assoc_args['page-url'] );
+
+    }else{
+
+      // get all methods function
+      $all_methods = boolval( $assoc_args[ 'all-methods' ] );
+
+      Cachify::flush_total_cache( $all_methods );
+
+    }
 
     WP_CLI::success( "Cache flushed" );
 
   }
 
+  /**
+	 * Get cache size
+	 *
+	 * @since   2.3.0
+	 * @change  2.3.0
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+  public static function get_cache_size( $args, $assoc_args ){
+
+    $assoc_args = wp_parse_args( $assoc_args, array( 'raw' => false ) );
+
+    $cache_size = Cachify::get_cache_size();
+
+    if( $assoc_args["raw"] ){
+      $message = $cache_size;
+    }else{
+      $message = "The cache size is $cache_size bytes";
+    }
+
+    WP_CLI::line( $message );
+
+  }
+
+  /**
+   * Register CLI Commands
+   *
+   * @since   2.3.0
+   * @change  2.3.0
+   */
   public static function add_commands() {
     if ( defined( 'WP_CLI' ) && WP_CLI ) {
       $cmd_optimize = function( $args, $assoc_args ) { self::optimize( $args, $assoc_args ); };
+
+      /*
+       * Add flush command
+       */
       WP_CLI::add_command(
         'cachify flush',
         array(
@@ -32,11 +97,48 @@ final class Cachify_CLI {
                 array(
                     'type'     => 'flag',
                     'name'     => 'all-methods',
+                    'description'   => 'Flush all caching methods',
+                    'optional' => true,
+                ),
+                array(
+                    'type'     => 'assoc',
+                    'name'     => 'ids',
+                    'description'   => 'Flush cache for specific IDs',
+                    'optional' => true,
+                ),
+                array(
+                    'type'     => 'assoc',
+                    'name'     => 'page-url',
+                    'description'   => 'Flush cache for a specific IDs',
                     'optional' => true,
                 ),
             ),
         )
       );
+
+      /*
+       * Add cache-size command
+       */
+      WP_CLI::add_command(
+        'cachify cache-size',
+        array(
+          'Cachify_CLI',
+          'get_cache_size',
+        ),
+        array(
+            'shortdesc' => 'Get the size of the cache',
+            'synopsis'  => array(
+                array(
+                    'type'     => 'flag',
+                    'name'     => 'raw',
+                    'description'   => 'Raw size output',
+                    'optional' => true,
+                ),
+            ),
+        )
+      );
+
+
     }
   }
 }

--- a/inc/cachify_cli.class.php
+++ b/inc/cachify_cli.class.php
@@ -6,7 +6,7 @@
 final class Cachify_CLI {
 
   /**
-	 * Flush Cache
+	 * Flush Cache Callback
 	 *
 	 * @since   2.3.0
 	 * @change  2.3.0
@@ -17,31 +17,9 @@ final class Cachify_CLI {
   public static function flush_cache( $args, $assoc_args ){
 
     // set default args
-    $assoc_args = wp_parse_args( $assoc_args, array( 'all-methods' => false, 'ids' => null, 'page-url' => null ) );
+    $assoc_args = wp_parse_args( $assoc_args, array( 'all-methods' => false ) );
 
-    if( $assoc_args['ids'] ){
-
-      // convert id list to array
-      $ids = explode( ',', $assoc_args['ids'] );
-
-      foreach ( $ids as $id ) {
-        Cachify::remove_page_cache_by_post_id( $id );
-        WP_CLI::line( 'Cache flushed for ID ' . $id );
-      }
-
-    }elseif ( $assoc_args['page-url'] ) {
-
-      Cachify::remove_page_cache_by_url( $assoc_args['page-url'] );
-      WP_CLI::line( 'Cache flushed for URL ' . $assoc_args['page-url'] );
-
-    }else{
-
-      // get all methods function
-      $all_methods = boolval( $assoc_args[ 'all-methods' ] );
-
-      Cachify::flush_total_cache( $all_methods );
-
-    }
+    Cachify::flush_total_cache( $all_methods );
 
     WP_CLI::success( "Cache flushed" );
 
@@ -58,8 +36,10 @@ final class Cachify_CLI {
 	 */
   public static function get_cache_size( $args, $assoc_args ){
 
+    // set default args
     $assoc_args = wp_parse_args( $assoc_args, array( 'raw' => false ) );
 
+    // get cache size
     $cache_size = Cachify::get_cache_size();
 
     if( $assoc_args["raw"] ){
@@ -99,19 +79,7 @@ final class Cachify_CLI {
                     'name'     => 'all-methods',
                     'description'   => 'Flush all caching methods',
                     'optional' => true,
-                ),
-                array(
-                    'type'     => 'assoc',
-                    'name'     => 'ids',
-                    'description'   => 'Flush cache for specific IDs',
-                    'optional' => true,
-                ),
-                array(
-                    'type'     => 'assoc',
-                    'name'     => 'page-url',
-                    'description'   => 'Flush cache for a specific IDs',
-                    'optional' => true,
-                ),
+                )
             ),
         )
       );
@@ -126,18 +94,17 @@ final class Cachify_CLI {
           'get_cache_size',
         ),
         array(
-            'shortdesc' => 'Get the size of the cache',
+            'shortdesc' => 'Get the size of the cache in bytes',
             'synopsis'  => array(
                 array(
                     'type'     => 'flag',
                     'name'     => 'raw',
-                    'description'   => 'Raw size output',
+                    'description'   => 'Raw size output in bytes',
                     'optional' => true,
                 ),
             ),
         )
       );
-
 
     }
   }


### PR DESCRIPTION
This PR adds basic CLI Commands for Cachify:

## Flush Command
`wp cachify flush`

This command flushes the total cache. 
This is equal to the `Cachify::flush_total_cache();`

### Available Options
The flush command accepts the `--all-methods` option to flush the cache of all methods.
This is euqal to `Cachify::flush_total_cache( true );`

## Cache Size Command
`wp cachify cache-size`

This command returns the current cache size.
Example Output: `The cache size is 120188 bytes`

### Available Options
The Cache Size command accepts the `--raw` option to return only the cache size in bytes.
Example Output: `120188`