### PR TITLE
Flush cache on term change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,20 @@ All notable changes to this project will be documented in this file. This projec
 * Enhance - FAQ and Support links, see #55, props timse201
 * Enhance - Add text caption to "flush cache" button
 * Security - Tabnabbing prevention, see #55, props timse201
+* New: `cachify_flush_cache_hooks` filter added to modify all hooks that flush the cache
+* Improvement: Flush Cache when a user is created / updated / deleted
+* Code-Refactoring
 
 ## 2.2.4
 * Fixes caching for mixed HTTPS and HTTP setups
 * Fixes an issue with the icon styling in the admin toolbar
 * Ensures compatibility with the latest WordPress version
-* Ensures compatibility with the latest WordPress version
-* New: `cachify_flush_cache_hooks` filter added to modify all hooks that flush the cache
-* Improvement: Flush Cache when a term is created / updated / deleted
-* Improvement: Flush Cache when a user is created / updated / deleted
-* Code-Refactoring
 
 ## 2.2.3
 * New: Generated a POT file
 * New: Added German formal translation
 * Updated, translated + formatted README.md
+* Updated expired link URLs in plugin and languages files
 * Updated plugin authors
 
 ## 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ All notable changes to this project will be documented in this file. This projec
 * Fixes caching for mixed HTTPS and HTTP setups
 * Fixes an issue with the icon styling in the admin toolbar
 * Ensures compatibility with the latest WordPress version
+* Ensures compatibility with the latest WordPress version
+* New: `cachify_flush_cache_hooks` filter added to modify all hooks that flush the cache
+* Improvement: Flush Cache when a term is created / updated / deleted
+* Improvement: Flush Cache when a user is created / updated / deleted
+* Code-Refactoring
 
 ## 2.2.3
 * New: Generated a POT file
 * New: Added German formal translation
 * Updated, translated + formatted README.md
-* Updated expired link URLs in plugin and languages files
 * Updated plugin authors
 
 ## 2.2.2

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -91,7 +91,7 @@ final class Cachify {
 		);
 
 		/* Flush Hooks */
-		self::register_flush_cache_hooks();
+		add_action( 'init', array( __CLASS__, 'register_flush_cache_hooks' ), 10, 0 );
 
 		add_action(
 			'cachify_remove_post_cache',

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1098,63 +1098,30 @@ final class Cachify {
 
 		/* Define all default flush cache hooks */
 		$flush_cache_hooks = array(
-			array(
-				'action' => 'cachify_flush_cache',
-				'priority' => 10
-			),
-			array(
-				'action' => '_core_updated_successfully',
-				'priority' => 10
-			),
-			array(
-				'action' => 'switch_theme',
-				'priority' => 10
-			),
-			array(
-				'action' => 'before_delete_post',
-				'priority' => 10
-			),
-			array(
-				'action' => 'wp_trash_post',
-				'priority' => 10
-			),
-			array(
-				'action' => 'create_term',
-				'priority' => 10
-			),
-			array(
-				'action' => 'delete_term',
-				'priority' => 10
-			),
-			array(
-				'action' => 'edit_terms',
-				'priority' => 10
-			),
-			array(
-				'action' => 'user_register',
-				'priority' => 10
-			),
-			array(
-				'action' => 'edit_user_profile_update',
-				'priority' => 10
-			),
-			array(
-				'action' => 'delete_user',
-				'priority' => 10
-			)
+			'cachify_flush_cache' 				=> 10,
+			'_core_updated_successfully'	=> 10,
+			'switch_theme'								=> 10,
+			'before_delete_post'					=> 10,
+			'wp_trash_post'								=> 10,
+			'create_term'									=> 10,
+			'delete_term'									=> 10,
+			'edit_terms'									=> 10,
+			'user_register'								=> 10,
+			'edit_user_profile_update'		=> 10,
+			'delete_user'									=> 10
 		);
 
 		$flush_cache_hooks = apply_filters( 'cachify_flush_cache_hooks', $flush_cache_hooks );
 
 		/* Loop all hooks and register actions */
-		foreach ($flush_cache_hooks as $hook) {
+		foreach ($flush_cache_hooks as $hook => $priority) {
 			add_action(
-				$hook["action"],
+				$hook,
 				array(
 					'Cachify',
 					'flush_total_cache',
 				),
-				$hook["priority"],
+				$priority,
 				0
 			);
 		}

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1129,6 +1129,18 @@ final class Cachify {
 			array(
 				'action' => 'edit_terms',
 				'priority' => 10
+			),
+			array(
+				'action' => 'user_register',
+				'priority' => 10
+			),
+			array(
+				'action' => 'edit_user_profile_update',
+				'priority' => 10
+			),
+			array(
+				'action' => 'delete_user',
+				'priority' => 10
 			)
 		);
 

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1094,27 +1094,27 @@ final class Cachify {
 	 * @param   void
 	 * @return  void
 	 */
-	public static function register_flush_cache_hooks(){
+	public static function register_flush_cache_hooks() {
 
 		/* Define all default flush cache hooks */
 		$flush_cache_hooks = array(
-			'cachify_flush_cache' 				=> 10,
-			'_core_updated_successfully'	=> 10,
-			'switch_theme'								=> 10,
-			'before_delete_post'					=> 10,
-			'wp_trash_post'								=> 10,
-			'create_term'									=> 10,
-			'delete_term'									=> 10,
-			'edit_terms'									=> 10,
-			'user_register'								=> 10,
-			'edit_user_profile_update'		=> 10,
-			'delete_user'									=> 10
+			'cachify_flush_cache' => 10,
+			'_core_updated_successfully' => 10,
+			'switch_theme' => 10,
+			'before_delete_post' => 10,
+			'wp_trash_post' => 10,
+			'create_term' => 10,
+			'delete_term' => 10,
+			'edit_terms' => 10,
+			'user_register' => 10,
+			'edit_user_profile_update' => 10,
+			'delete_user' => 10
 		);
 
 		$flush_cache_hooks = apply_filters( 'cachify_flush_cache_hooks', $flush_cache_hooks );
 
 		/* Loop all hooks and register actions */
-		foreach ($flush_cache_hooks as $hook => $priority) {
+		foreach ( $flush_cache_hooks as $hook => $priority ) {
 			add_action(
 				$hook,
 				array(

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -91,75 +91,13 @@ final class Cachify {
 		);
 
 		/* Flush Hooks */
+		self::register_flush_cache_hooks();
+
 		add_action(
 			'cachify_remove_post_cache',
 			array(
 				__CLASS__,
 				'remove_page_cache_by_post_id',
-			)
-		);
-
-		add_action(
-			'cachify_flush_cache',
-			array(
-				__CLASS__,
-				'flush_total_cache',
-			)
-		);
-
-		add_action(
-			'_core_updated_successfully',
-			array(
-				__CLASS__,
-				'flush_total_cache',
-			)
-		);
-
-		add_action(
-			'switch_theme',
-			array(
-				__CLASS__,
-				'flush_total_cache',
-			)
-		);
-
-		add_action(
-			'before_delete_post',
-			array(
-				__CLASS__,
-				'flush_total_cache',
-			)
-		);
-
-		add_action(
-			'wp_trash_post',
-			array(
-				__CLASS__,
-				'flush_total_cache',
-			)
-		);
-
-		add_action(
-			'create_term',
-			array(
-				__CLASS__,
-				'flush_total_cache',
-			)
-		);
-
-		add_action(
-			'delete_term',
-			array(
-				__CLASS__,
-				'flush_total_cache',
-			)
-		);
-
-		add_action(
-			'edit_terms',
-			array(
-				__CLASS__,
-				'flush_total_cache',
 			)
 		);
 
@@ -1146,6 +1084,68 @@ final class Cachify {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Register all hooks to flush the total cache
+	 *
+	 * @since   2.4.0  Make the function public
+	 *
+	 * @param   void
+	 * @return  void
+	 */
+	private static function register_flush_cache_hooks(){
+
+		/* Define all default flush cache hooks */
+		$flush_cache_hooks = array(
+			array(
+				'action' => 'cachify_flush_cache',
+				'priority' => 10
+			),
+			array(
+				'action' => '_core_updated_successfully',
+				'priority' => 10
+			),
+			array(
+				'action' => 'switch_theme',
+				'priority' => 10
+			),
+			array(
+				'action' => 'before_delete_post',
+				'priority' => 10
+			),
+			array(
+				'action' => 'wp_trash_post',
+				'priority' => 10
+			),
+			array(
+				'action' => 'create_term',
+				'priority' => 10
+			),
+			array(
+				'action' => 'delete_term',
+				'priority' => 10
+			),
+			array(
+				'action' => 'edit_terms',
+				'priority' => 10
+			)
+		);
+
+		$flush_cache_hooks = apply_filters( 'cachify_flush_cache_hooks', $flush_cache_hooks );
+
+		/* Loop all hooks and register actions */
+		foreach ($flush_cache_hooks as $hook) {
+			add_action(
+				$hook["action"],
+				array(
+					'Cachify',
+					'flush_total_cache',
+				),
+				$hook["priority"]
+			);
+		}
+
 	}
 
 	/**

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1089,7 +1089,7 @@ final class Cachify {
 	/**
 	 * Register all hooks to flush the total cache
 	 *
-	 * @since   2.4.0  Make the function public
+	 * @since   2.4.0
 	 *
 	 * @param   void
 	 * @return  void

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -1094,7 +1094,7 @@ final class Cachify {
 	 * @param   void
 	 * @return  void
 	 */
-	private static function register_flush_cache_hooks(){
+	public static function register_flush_cache_hooks(){
 
 		/* Define all default flush cache hooks */
 		$flush_cache_hooks = array(
@@ -1154,7 +1154,8 @@ final class Cachify {
 					'Cachify',
 					'flush_total_cache',
 				),
-				$hook["priority"]
+				$hook["priority"],
+				0
 			);
 		}
 

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -139,6 +139,30 @@ final class Cachify {
 			)
 		);
 
+		add_action(
+			'create_term',
+			array(
+				__CLASS__,
+				'flush_total_cache',
+			)
+		);
+
+		add_action(
+			'delete_term',
+			array(
+				__CLASS__,
+				'flush_total_cache',
+			)
+		);
+
+		add_action(
+			'edit_terms',
+			array(
+				__CLASS__,
+				'flush_total_cache',
+			)
+		);
+
 		/* Flush icon */
 		add_action(
 			'admin_bar_menu',


### PR DESCRIPTION
This PR is a fix for #167 

To create this functionality I hooked the `Cachify::flush_total_cache()` function on to three additional actions:

- `create_term` to clear the cache when a new term is created
- `edit_terms` to clear the cache when a term is updated.
- `delete_term` to clear the cache when a term is deleted

Because the nav menus are based on terms this modification also flushes the Cache when a nav menu is created, updated or deleted