### PR TITLE
Fix: Whole Network cleared after changing a page

### DIFF
--- a/inc/cachify_hdd.class.php
+++ b/inc/cachify_hdd.class.php
@@ -391,6 +391,12 @@ final class Cachify_HDD {
 			return true;
 		}
 
+		// If we are on the root blog in a subdirectory multisite we check if the current dir is the root dir
+		$root_site_dir = CACHIFY_CACHE_DIR . DIRECTORY_SEPARATOR . $ssl_prefix . DOMAIN_CURRENT_SITE . DIRECTORY_SEPARATOR;
+		if ( $root_site_dir === $file )  {
+			return false;
+		}
+
 		// If we are on the root blog in a subdirectory multisite, we check, if the current file
 		// is part of another blog.
 		global $wpdb;


### PR DESCRIPTION
closes #168 

I added another check to `Cachify_HDD::_user_can_delete()` method.

The method now checks if we are trying to delete the root folder of the main page. In this case `false` is returned which prevents deletion.

This way we ensure that the parent folder of a sub-site within a subdirectory-multisite is not delete.