### PR TITLE
Fix dashboard icon color in WordPress 5.3 (with fallback) and dark mode

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -2,7 +2,7 @@
 #dashboard_right_now .cachify-icon{
 	width: 19px;
 	height: 13px;
-	fill: #82878c;
+	fill: #606a73;
 }
 
 #dashboard_right_now li a.cachify-glance::before{

--- a/css/dashboard.min.css
+++ b/css/dashboard.min.css
@@ -1,1 +1,1 @@
-#dashboard_right_now .cachify-icon{width:19px;height:13px;fill:#82878c}#dashboard_right_now li a.cachify-glance::before{content:"";padding:0}
+#dashboard_right_now .cachify-icon{width:19px;height:13px;fill:#606a73}#dashboard_right_now li a.cachify-glance::before{content:"";padding:0}

--- a/inc/cachify.class.php
+++ b/inc/cachify.class.php
@@ -176,6 +176,22 @@ final class Cachify {
 			);
 
 			add_action(
+				'admin_head',
+				array(
+					__CLASS__,
+					'admin_dashboard_styles',
+				)
+			);
+
+			add_action(
+				'doing_dark_mode',
+				array(
+					__CLASS__,
+					'admin_dashboard_dark_mode_styles'
+				)
+			);
+
+			add_action(
 				'transition_comment_status',
 				array(
 					__CLASS__,
@@ -1427,6 +1443,28 @@ final class Cachify {
 			break;
 		}
 
+	}
+
+	/**
+	 * Fixing some admin dashboard styles
+	 *
+	 * @since 2.3.1
+	 */
+	public static function admin_dashboard_styles() {
+		$wp_version = get_bloginfo( 'version' );
+
+		if ( version_compare( $wp_version, '5.3', '<' ) ) {
+			echo '<style>#dashboard_right_now .cachify-icon use { fill: #82878c; }</style>';
+		}
+	}
+
+	/**
+	 * Fixing some admin dashboard styles
+	 *
+	 * @since 2.3.1
+	 */
+	public static function admin_dashboard_dark_mode_styles() {
+		echo '<style>#dashboard_right_now .cachify-icon use { fill: #bbc8d4; }</style>';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #173.