### PR TITLE
ignore README.md for distribution

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -16,3 +16,4 @@
 /package.json
 /package-lock.json
 /phpcs.xml
+/README.md


### PR DESCRIPTION
We do use a separate _readme.txt_ file for plugin distribution, so we should exclude the _README.md_.