### PR TITLE
reduce tags in readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 # Cachify #
 * Contributors:      pluginkollektiv
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Tags:              acceleration, apc, cache, caching, compress, database cache, db-cache, disk cache, disk caching, google, hdd, html compression, memcached, minify, minimize, optimize, page cache, performance, quick cache, speed
+* Tags:              acceleration, cache, caching, minimize, performance, apc, disk, hdd, memcached, compression, minify, speed
 * Requires at least: 4.4
 * Tested up to:      5.7
 * Requires PHP:      5.2.4


### PR DESCRIPTION
https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#section-details

"Tags – 1 to 12 comma separated terms that describe the plugin. Only the first five will show on the generated page, and anything over 12 will be detrimental to SEO. Plugins must refrain from using competitors plugin names as tags."

If you search for combined tags on WP like html compression or db-cache and only one of these words are described in tags, you will still be displayed