### PR TITLE
change composer action for deployment workflows

### DIFF
--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -9,7 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: php-actions/composer@v5
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          tools: composer
+      - name: Build
+        run: composer install
       - name: WordPress.org plugin asset/readme update
         uses: 10up/action-wordpress-plugin-asset-update@stable
         env:

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -10,7 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: php-actions/composer@v5
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          tools: composer
+      - name: Build
+        run: composer install
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:


### PR DESCRIPTION
The previous composer action adds some extra files to the project root. This PR resolves #218.

Those can be ignored, but the action used for testing is fast and allows to specify the exact PHP version whereas the composer action uses the latest stable (we stumbled upon this in other projects).

The `shivammathur/setup-php@v2` version has proven to work since #217, so why not use the same workflow in all 3 recipes...