### PR TITLE
chore: add cachify_buffer filter

### DIFF
--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1337,14 +1337,14 @@ final class Cachify {
 			/**
 			 * Filters the buffered data itself
 			 *
-			 * @since 2.3.2
+			 * @since 2.4
 			 *
 			 * @param string $data          The actual data.
 			 * @param object $method        Instance of the selected caching method.
 			 * @param string $cache_hash    The cache hash.
 			 * @param int    $cache_expires Cache validity period.
 			 */
-			$data = apply_filters( 'cachify_buffer', $data, self::$method, self::_cache_hash(), self::_cache_expires() );
+			$data = apply_filters( 'cachify_modify_output', $data, self::$method, self::_cache_hash(), self::_cache_expires() );
 
 			call_user_func(
 				array(

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1334,6 +1334,18 @@ final class Cachify {
 
 		/* Save? */
 		if ( $should_cache ) {
+			/**
+			 * Filters the buffered data itself
+			 *
+			 * @since 2.3.2
+			 *
+			 * @param string $data          The actual data.
+			 * @param object $method        Instance of the selected caching method.
+			 * @param string $cache_hash    The cache hash.
+			 * @param int    $cache_expires Cache validity period.
+			 */
+			$data = apply_filters( 'cachify_buffer', $data, self::$method, self::_cache_hash(), self::_cache_expires() );
+
 			call_user_func(
 				array(
 					self::$method,


### PR DESCRIPTION
Hi!

Here is the developer of [Real Cookie Banner](https://wordpress.org/plugins/real-cookie-banner/) and I want to make our plugin compatible with your caching solution. Unfortunately, your cache does save the output buffer "too early", so we cannot hook into.

We intend to "block" content until a user gives consent, so we need to alter the HTML code before it gets cached.

I would like to propose the following filter: `cachify_buffer`.

What do you think?

Regards,
Matthew 😊