### PR TITLE
do not use tables for setup instructions layout

### DIFF
--- a/inc/setup/cachify.apc.htaccess.php
+++ b/inc/setup/cachify.apc.htaccess.php
@@ -14,28 +14,17 @@ $beginning = '&lt;Files index.php&gt;
 $ending = '/cachify/apc/proxy.php
 &lt;/Files&gt;';
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp
 ?>
 
-	<table class="form-table">
-		<tr>
-			<th>
-			<?php esc_html_e( '.htaccess APC setup', 'cachify' ); ?>
-			</th>
-			<td>
-				<label for="cachify_setup">
-					<?php esc_html_e( 'Please add the following lines to your .htaccess file', 'cachify' ); ?>
-				</label>
-			</td>
-		</tr>
-	</table>
+<h2><?php esc_html_e( '.htaccess APC setup', 'cachify' ); ?></h2>
+<p><?php esc_html_e( 'Please add the following lines to your .htaccess file', 'cachify' ); ?></p>
 
-	<textarea rows="5" class="large-text code cachify-code" name="code" readonly>
-		<?php
-		printf(
-			'%s%s%s',
-			esc_html( $beginning ),
-			esc_html( WP_PLUGIN_DIR ),
-			esc_html( $ending )
-		);
-		?>
-	</textarea>
+<textarea rows="5" class="large-text code cachify-code" name="code" readonly><?php
+	printf(
+		'%s%s%s',
+		esc_html( $beginning ),
+		esc_html( WP_PLUGIN_DIR ),
+		esc_html( $ending )
+	);
+	?></textarea>

--- a/inc/setup/cachify.apc.nginx.php
+++ b/inc/setup/cachify.apc.nginx.php
@@ -22,30 +22,19 @@ $ending = '/cachify/apc/proxy.php</strong>;
   }
 }';
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp
 ?>
 
-	<table class="form-table">
-		<tr>
-			<th>
-				<?php esc_html_e( 'nginx APC setup', 'cachify' ); ?>
-			</th>
-			<td>
-				<label for="cachify_setup">
-					<?php esc_html_e( 'Please add the following lines to your nginx PHP configuration', 'cachify' ); ?>
-				</label>
-			</td>
-		</tr>
-	</table>
+<h2><?php esc_html_e( 'nginx APC setup', 'cachify' ); ?></h2>
+<p><?php esc_html_e( 'Please add the following lines to your nginx PHP configuration', 'cachify' ); ?></p>
 
-	<textarea rows="13" class="large-text code cachify-code" name="code" readonly>
-		<?php
-		printf(
-			'%s%s%s',
-			esc_html( $beginning ),
-			esc_html( WP_PLUGIN_DIR ),
-			esc_html( $ending )
-		);
-		?>
-	</textarea>
+<textarea rows="13" class="large-text code cachify-code" name="code" readonly><?php
+	printf(
+		'%s%s%s',
+		esc_html( $beginning ),
+		esc_html( WP_PLUGIN_DIR ),
+		esc_html( $ending )
+	);
+	?></textarea>
 
-	<small>(<?php esc_html_e( 'You might need to adjust the non-highlighted lines to your needs.', 'cachify' ); ?>)</small>
+<small>(<?php esc_html_e( 'You might need to adjust the non-highlighted lines to your needs.', 'cachify' ); ?>)</small>

--- a/inc/setup/cachify.hdd.htaccess.php
+++ b/inc/setup/cachify.hdd.htaccess.php
@@ -47,54 +47,40 @@ $middle = '/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html -f
 $ending = '/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:CACHIFY_SUFFIX} [L]
 &lt;/IfModule&gt;
 # END CACHIFY';
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp
 ?>
 
-	<table class="form-table">
-		<tr>
-			<th>
-				<?php esc_html_e( '.htaccess HDD setup', 'cachify' ); ?>
-			</th>
-			<td>
-				<?php esc_html_e( 'Please add the following lines to your .htaccess file', 'cachify' ); ?>
-			</td>
-		</tr>
+<h2><?php esc_html_e( '.htaccess HDD setup', 'cachify' ); ?></h2>
+<p><?php esc_html_e( 'Please add the following lines to your .htaccess file', 'cachify' ); ?></p>
 
-		<tr>
-			<th>
-				<?php esc_html_e( 'Notes', 'cachify' ); ?>
-			</th>
-			<td>
-				<ul style="list-style-type:circle">
-					<li>
-						<?php esc_html_e( 'Within .htaccess, the extension has a higher priority and must be placed above the WordPress Rewrite rules (marked mostly by # BEGIN WordPress … # END WordPress).', 'cachify' ); ?>
-					</li>
-					<li>
-						<?php esc_html_e( 'Changes to the .htaccess file can not be made if PHP is run as fcgi.', 'cachify' ); ?>
-					</li>
-					<li>
-						<?php esc_html_e( 'If there are partial errors in the redirects within the blog, the shutdown of the Apache Content Cache can help:', 'cachify' ); ?><br />
-						<pre>&lt;IfModule mod_cache.c&gt;
-  CacheDisable /
+<textarea rows="16" class="large-text code cachify-code" name="code" readonly><?php
+	printf(
+		'%s%s%s%s%s',
+		esc_html( $beginning ),
+		esc_html( WP_CONTENT_DIR ),
+		esc_html( $middle ),
+		esc_html( wp_make_link_relative( content_url() ) ),
+		esc_html( $ending )
+	);
+	?></textarea>
+
+<h3><?php esc_html_e( 'Notes', 'cachify' ); ?></h3>
+<ol>
+	<li>
+		<?php esc_html_e( 'Within .htaccess, the extension has a higher priority and must be placed above the WordPress Rewrite rules (marked mostly by # BEGIN WordPress … # END WordPress).', 'cachify' ); ?>
+	</li>
+	<li>
+		<?php esc_html_e( 'Changes to the .htaccess file can not be made if PHP is run as fcgi.', 'cachify' ); ?>
+	</li>
+	<li>
+		<?php esc_html_e( 'If there are partial errors in the redirects within the blog, the shutdown of the Apache Content Cache can help:', 'cachify' ); ?><br />
+		<pre>&lt;IfModule mod_cache.c&gt;
+CacheDisable /
 &lt;/IfModule&gt;</pre>
-					</li>
-					<li>
-						<?php esc_html_e( 'In case of special character errors, you can add the following to the .htaccess file:', 'cachify' ); ?><br />
-						<pre>AddDefaultCharset UTF-8</pre>
-					</li>
-				</ul>
-			</td>
-		</tr>
-	</table>
-
-	<textarea rows="16" class="large-text code cachify-code" name="code" readonly>
-		<?php
-		printf(
-			'%s%s%s%s%s',
-			esc_html( $beginning ),
-			esc_html( WP_CONTENT_DIR ),
-			esc_html( $middle ),
-			esc_html( wp_make_link_relative( content_url() ) ),
-			esc_html( $ending )
-		);
-		?>
-	</textarea>
+	</li>
+	<li>
+		<?php esc_html_e( 'In case of special character errors, you can add the following to the .htaccess file:', 'cachify' ); ?><br />
+		<pre>AddDefaultCharset UTF-8</pre>
+	</li>
+</ol>

--- a/inc/setup/cachify.hdd.nginx.php
+++ b/inc/setup/cachify.hdd.nginx.php
@@ -9,40 +9,10 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 
-	<table class="form-table">
-		<tr>
-			<th>
-				<?php esc_html_e( 'nginx HDD setup', 'cachify' ); ?>
-			</th>
-			<td>
-				<label for="cachify_setup">
-					<?php esc_html_e( 'Please add the following lines to your nginx.conf', 'cachify' ); ?>
-				</label>
-			</td>
-		</tr>
+<h2><?php esc_html_e( 'nginx HDD setup', 'cachify' ); ?></h2>
+<p><?php esc_html_e( 'Please add the following lines to your nginx.conf', 'cachify' ); ?></p>
 
-		<tr>
-			<th>
-				<?php esc_html_e( 'Notes', 'cachify' ); ?>
-			</th>
-			<td>
-				<ul style="list-style-type:circle">
-					<li>
-						<?php
-						printf(
-							/* translators: variable names*/
-							esc_html__( 'For domains with FQDN, the variable %1$s must be used instead of %2$s.', 'cachify' ),
-							'<code>${http_host}</code>',
-							'<code>${host}</code>'
-						);
-						?>
-					</li>
-				</ul>
-			</td>
-		</tr>
-	</table>
-
-	<textarea rows="16" class="large-text code cachify-code" name="code" readonly>
+<textarea rows="16" class="large-text code cachify-code" name="code" readonly>
 ## GZIP
 gzip_static on;
 
@@ -81,3 +51,17 @@ location ~ /wp-content/cache {
 </textarea>
 
 <small>(<?php esc_html_e( 'You might need to adjust the location directives to your needs.', 'cachify' ); ?>)</small>
+
+<h3><?php esc_html_e( 'Notes', 'cachify' ); ?></h3>
+<ol>
+	<li>
+		<?php
+		printf(
+			/* translators: variable names*/
+			esc_html__( 'For domains with FQDN, the variable %1$s must be used instead of %2$s.', 'cachify' ),
+			'<code>${http_host}</code>',
+			'<code>${host}</code>'
+		);
+		?>
+	</li>
+</ol>

--- a/inc/setup/cachify.memcached.nginx.php
+++ b/inc/setup/cachify.memcached.nginx.php
@@ -9,50 +9,10 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 
-	<table class="form-table">
-		<tr>
-			<th>
-				<?php esc_html_e( 'nginx Memcached setup', 'cachify' ); ?>
-			</th>
-			<td>
-				<label for="cachify_setup">
-					<?php esc_html_e( 'Please add the following lines to your nginx.conf', 'cachify' ); ?>
-				</label>
-			</td>
-		</tr>
+<h2><?php esc_html_e( 'nginx Memcached setup', 'cachify' ); ?></h2>
+<p><?php esc_html_e( 'Please add the following lines to your nginx.conf', 'cachify' ); ?></p>
 
-		<tr>
-			<th>
-				<?php esc_html_e( 'Notes', 'cachify' ); ?>
-			</th>
-			<td>
-				<ul style="list-style-type:circle">
-					<li>
-						<?php
-						printf(
-							/* translators: variable names*/
-							esc_html__( 'For domains with FQDN, the variable %1$s must be used instead of %2$s.', 'cachify' ),
-							'<code>${http_host}</code>',
-							'<code>${host}</code>'
-						);
-						?>
-					</li>
-					<li>
-						<?php
-						printf(
-							/* translators: code */
-							esc_html__( 'If you have errors please try to change %1$s to %2$s This forces IPv4 because some servers that allow IPv4 and IPv6 are configured to bind memcached to IPv4 only.', 'cachify' ),
-							'<code>memcached_pass localhost:11211;</code>',
-							'<code>memcached_pass 127.0.0.1:11211;</code>'
-						);
-						?>
-					</li>
-				</ul>
-			</td>
-		</tr>
-	</table>
-
-	<textarea rows="16" class="large-text code cachify-code" name="code" readonly>
+<textarea rows="16" class="large-text code cachify-code" name="code" readonly>
 ## GZIP
 gzip_static on;
 
@@ -89,3 +49,27 @@ location @nocache {
 </textarea>
 
 <small>(<?php esc_html_e( 'You might need to adjust the location directives to your needs.', 'cachify' ); ?>)</small>
+
+<h3><?php esc_html_e( 'Notes', 'cachify' ); ?></h3>
+<ol>
+	<li>
+		<?php
+		printf(
+			/* translators: variable names*/
+			esc_html__( 'For domains with FQDN, the variable %1$s must be used instead of %2$s.', 'cachify' ),
+			'<code>${http_host}</code>',
+			'<code>${host}</code>'
+		);
+		?>
+	</li>
+	<li>
+		<?php
+		printf(
+			/* translators: code */
+			esc_html__( 'If you have errors please try to change %1$s to %2$s This forces IPv4 because some servers that allow IPv4 and IPv6 are configured to bind memcached to IPv4 only.', 'cachify' ),
+			'<code>memcached_pass localhost:11211;</code>',
+			'<code>memcached_pass 127.0.0.1:11211;</code>'
+		);
+		?>
+	</li>
+</ol>


### PR DESCRIPTION
Replace `<table>` and `<label>` markup by headlines (`<h2>`, `<h3>`) and paragraphs (`<p>`).

Move notes section below the config file excerpt.

Remove leading/trailing whitespaces and line breaks in `<textarea>` content.