### PR TITLE
Fix issue with port in URL

### DIFF
--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1006,6 +1006,7 @@ final class Cachify {
 	 *
 	 * @since   0.1
 	 * @change  2.0
+	 * @change  2.4.0 Fix issue with port in URL.
 	 *
 	 * @param   string $url  URL to hash [optional].
 	 * @return  string       Cachify hash value.

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1012,15 +1012,14 @@ final class Cachify {
 	 */
 	private static function _cache_hash( $url = '' ) {
 		$prefix = is_ssl() ? 'https-' : '';
-		$url_parts = wp_parse_url( $url );
 
 		if ( empty( $url ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			$hash_key = $prefix . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] );
-		} else {
-			$hash_key = $prefix . $url_parts['host'] . $url_parts['path'];
+			$url = wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] );
 		}
 
+		$url_parts = wp_parse_url( $url );
+		$hash_key = $prefix . $url_parts['host'] . $url_parts['path'];
 		return md5( $hash_key ) . '.cachify';
 	}
 


### PR DESCRIPTION
Fixes #250.

The problem with the current code is, that the generated hash from `Cachify::_cache_hash()` is different for URLs with a port, depending on if the `$url` method param is empty or not. The reason for that is, that the port is part of `$_SERVER['HTTP_HOST']` but not `$url_parts['host']`.

This PR modifies the code, so that, if `$url` is empty, the URL from the `$_SERVER` values is saved in `$url`, and the generation of the string for the hash is equal for both cases.