### PR TITLE
Add HDD Cache expiration cron

### DIFF
--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -32,7 +32,9 @@ defined( 'ABSPATH' ) || exit;
 			<td>
 				<input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="<?php echo esc_attr( $options['cache_expires'] ); ?>" class="small-text" />
 				<?php esc_html_e( 'Hours', 'cachify' ); ?>
-				<p class="description"><?php esc_html_e( 'HDD cache will only expire correctly when triggered by a system cron.', 'cachify' ); ?></p>
+				<?php if ( self::METHOD_HDD === $options['use_apc'] ) : ?>
+					<p class="description"><?php esc_html_e( 'HDD cache will only expire correctly when triggered by a system cron.', 'cachify' ); ?></p>
+				<?php endif; ?>
 
 				<p class="description">
 					<?php

--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -30,14 +30,9 @@ defined( 'ABSPATH' ) || exit;
 				<label for="cachify_cache_expires"><?php esc_html_e( 'Cache expiration', 'cachify' ); ?></label>
 			</th>
 			<td>
-				<?php if ( self::METHOD_HDD === $options['use_apc'] ) : ?>
-					<input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="" disabled="disabled" class="small-text" />
-					<?php esc_html_e( 'Hours', 'cachify' ); ?>
-					<p class="description"><?php esc_html_e( 'HDD cache will only expire as you update posts or flush it yourself.', 'cachify' ); ?></p>
-				<?php else : ?>
-					<input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="<?php echo esc_attr( $options['cache_expires'] ); ?>" class="small-text" />
-					<?php esc_html_e( 'Hours', 'cachify' ); ?>
-				<?php endif; ?>
+				<input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="<?php echo esc_attr( $options['cache_expires'] ); ?>" class="small-text" />
+				<?php esc_html_e( 'Hours', 'cachify' ); ?>
+				<p class="description"><?php esc_html_e( 'HDD cache will only expire correctly when triggered by a system cron.', 'cachify' ); ?></p>
 
 				<p class="description">
 					<?php

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -144,7 +144,7 @@ final class Cachify {
 
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
 			if ( $timestamp == false ) {
-				wp_schedule_event( time(), 'cache_expire', 'hdd_cache_cron' );
+				wp_schedule_event( time(), 'cashify_cache_expire', 'hdd_cache_cron' );
 			}
 
 			add_action(
@@ -563,7 +563,7 @@ final class Cachify {
 	 * @return array
 	 */
 	public static function add_cron_cache_expiration() {
-		$schedules['cache_expire'] = array(
+		$schedules['cashify_cache_expire'] = array(
 			'interval' => self::$options['cache_expires'] * 3600,
 			'display'  => 'Cache Expiration',
 		);
@@ -830,7 +830,7 @@ final class Cachify {
 		if ( self::METHOD_HDD == self::$options['use_apc'] ) {
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
 			if ( $timestamp !== false ) {
-				wp_reschedule_event( $timestamp, 'cache_expire', 'hdd_cache_cron' );
+				wp_reschedule_event( $timestamp, 'cashify_cache_expire', 'hdd_cache_cron' );
 				wp_unschedule_event( $timestamp, 'hdd_cache_cron' );
 			}
 		}

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -562,7 +562,7 @@ final class Cachify {
 	 *
 	 * @return array
 	 */
-	public static function add_cron_cache_expiration() {
+	public static function add_cron_cache_expiration( $schedules ) {
 		$schedules['cachify_cache_expire'] = array(
 			'interval' => self::$options['cache_expires'] * 3600,
 			'display'  => esc_html__( 'Cachify expire', 'cachify' ),

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -565,7 +565,7 @@ final class Cachify {
 	public static function add_cron_cache_expiration() {
 		$schedules['cashify_cache_expire'] = array(
 			'interval' => self::$options['cache_expires'] * 3600,
-			'display'  => __( 'Cachify expire', 'cachify' ),
+			'display'  => esc_html__( 'Cachify expire', 'cachify' ),
 		);
 		return $schedules;
 	}

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -565,7 +565,7 @@ final class Cachify {
 	public static function add_cron_cache_expiration() {
 		$schedules['cashify_cache_expire'] = array(
 			'interval' => self::$options['cache_expires'] * 3600,
-			'display'  => 'Cache Expiration',
+			'display'  => 'Cachify',
 		);
 		return $schedules;
 	}

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -143,7 +143,7 @@ final class Cachify {
 			);
 
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
-			if ( $timestamp == false ) {
+			if (false == $timestamp) {
 				wp_schedule_event( time(), 'cashify_cache_expire', 'hdd_cache_cron' );
 			}
 
@@ -297,7 +297,7 @@ final class Cachify {
 		/* Remove hdd cache cron when hdd is selected */
 		if ( self::METHOD_HDD == self::$options['use_apc'] ) {
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
-			if ( $timestamp !== false ) {
+			if ( false != $timestamp ) {
 				wp_unschedule_event( $timestamp, 'hdd_cache_cron' );
 			}
 		}
@@ -829,7 +829,7 @@ final class Cachify {
 		/* Reschedule HDD Cache Cron */
 		if ( self::METHOD_HDD == self::$options['use_apc'] ) {
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
-			if ( $timestamp !== false ) {
+			if ( false != $timestamp ) {
 				wp_reschedule_event( $timestamp, 'cashify_cache_expire', 'hdd_cache_cron' );
 				wp_unschedule_event( $timestamp, 'hdd_cache_cron' );
 			}

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -132,7 +132,7 @@ final class Cachify {
 			2
 		);
 
-		/* Add Cron for clearing the HDD Cache daily */
+		/* Add Cron for clearing the HDD Cache */
 		if ( self::METHOD_HDD == self::$options['use_apc'] ) {
 			add_filter(
 				'cron_schedules',
@@ -547,9 +547,9 @@ final class Cachify {
 	}
 
 	/**
-	 * HDD Cache expiration cron
+	 * HDD Cache expiration cron action
 	 *
-	 * @since   2.3.3
+	 * @since  2.3.3
 	 */
 	public static function run_hdd_cache_cron() {
 		Cachify_HDD::clear_cache();
@@ -558,7 +558,7 @@ final class Cachify {
 	/**
 	 * Add cache expiration cron shedule
 	 *
-	 * @since 2.3.3
+	 * @since  2.3.3
 	 *
 	 * @return array
 	 */

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -558,9 +558,11 @@ final class Cachify {
 	/**
 	 * Add cache expiration cron schedule.
 	 *
-	 * @since 2.4
+	 * @param array $schedules Array of previously added non-default schedules.
 	 *
-	 * @return array
+	 * @return array Array of non-default schedules with our tasks added.
+	 *
+	 * @since 2.4
 	 */
 	public static function add_cron_cache_expiration( $schedules ) {
 		$schedules['cachify_cache_expire'] = array(

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -565,7 +565,7 @@ final class Cachify {
 	public static function add_cron_cache_expiration() {
 		$schedules['cashify_cache_expire'] = array(
 			'interval' => self::$options['cache_expires'] * 3600,
-			'display'  => 'Cachify',
+			'display'  => __( 'Cachify expire', 'cachify' ),
 		);
 		return $schedules;
 	}

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -143,7 +143,7 @@ final class Cachify {
 			);
 
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
-			if (false == $timestamp) {
+			if ( false == $timestamp ) {
 				wp_schedule_event( time(), 'cashify_cache_expire', 'hdd_cache_cron' );
 			}
 

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -133,7 +133,7 @@ final class Cachify {
 		);
 
 		/* Add Cron for clearing the HDD Cache */
-		if ( self::METHOD_HDD == self::$options['use_apc'] ) {
+		if ( self::METHOD_HDD === self::$options['use_apc'] ) {
 			add_filter(
 				'cron_schedules',
 				array(
@@ -143,7 +143,7 @@ final class Cachify {
 			);
 
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
-			if ( false == $timestamp ) {
+			if ( false === $timestamp ) {
 				wp_schedule_event( time(), 'cashify_cache_expire', 'hdd_cache_cron' );
 			}
 
@@ -295,9 +295,9 @@ final class Cachify {
 	 */
 	public static function on_deactivation() {
 		/* Remove hdd cache cron when hdd is selected */
-		if ( self::METHOD_HDD == self::$options['use_apc'] ) {
+		if ( self::METHOD_HDD === self::$options['use_apc'] ) {
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
-			if ( false != $timestamp ) {
+			if ( false !== $timestamp ) {
 				wp_unschedule_event( $timestamp, 'hdd_cache_cron' );
 			}
 		}
@@ -827,9 +827,9 @@ final class Cachify {
 		}
 
 		/* Reschedule HDD Cache Cron */
-		if ( self::METHOD_HDD == self::$options['use_apc'] ) {
+		if ( self::METHOD_HDD === self::$options['use_apc'] ) {
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
-			if ( false != $timestamp ) {
+			if ( false !== $timestamp ) {
 				wp_reschedule_event( $timestamp, 'cashify_cache_expire', 'hdd_cache_cron' );
 				wp_unschedule_event( $timestamp, 'hdd_cache_cron' );
 			}

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -144,7 +144,7 @@ final class Cachify {
 
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
 			if ( false === $timestamp ) {
-				wp_schedule_event( time(), 'cashify_cache_expire', 'hdd_cache_cron' );
+				wp_schedule_event( time(), 'cachify_cache_expire', 'hdd_cache_cron' );
 			}
 
 			add_action(
@@ -547,23 +547,23 @@ final class Cachify {
 	}
 
 	/**
-	 * HDD Cache expiration cron action
+	 * HDD Cache expiration cron action.
 	 *
-	 * @since  2.3.3
+	 * @since 2.4
 	 */
 	public static function run_hdd_cache_cron() {
 		Cachify_HDD::clear_cache();
 	}
 
 	/**
-	 * Add cache expiration cron shedule
+	 * Add cache expiration cron schedule.
 	 *
-	 * @since  2.3.3
+	 * @since 2.4
 	 *
 	 * @return array
 	 */
 	public static function add_cron_cache_expiration() {
-		$schedules['cashify_cache_expire'] = array(
+		$schedules['cachify_cache_expire'] = array(
 			'interval' => self::$options['cache_expires'] * 3600,
 			'display'  => esc_html__( 'Cachify expire', 'cachify' ),
 		);
@@ -830,7 +830,7 @@ final class Cachify {
 		if ( self::METHOD_HDD === self::$options['use_apc'] ) {
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
 			if ( false !== $timestamp ) {
-				wp_reschedule_event( $timestamp, 'cashify_cache_expire', 'hdd_cache_cron' );
+				wp_reschedule_event( $timestamp, 'cachify_cache_expire', 'hdd_cache_cron' );
 				wp_unschedule_event( $timestamp, 'hdd_cache_cron' );
 			}
 		}


### PR DESCRIPTION
This PR adds an wp_cron for clearing the hdd cache.

The option for changing the expiration time is reenabled when hdd is selected.
On the Settings page a small information is added which informs the user that an system cron should be used (only when hdd is selected).