### PR TITLE
Remove unnecessary @ operators

### DIFF
--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -185,6 +185,7 @@ final class Cachify_HDD {
 	 */
 	private static function _create_file( $file, $data ) {
 		/* Writable? */
+
 		$handle = @fopen( $file, 'wb' );
 		if ( ! $handle ) {
 			trigger_error( esc_html( __METHOD__ . ": Could not write file {$file}.", E_USER_WARNING ) );
@@ -192,7 +193,7 @@ final class Cachify_HDD {
 		}
 
 		/* Write */
-		@fwrite( $handle, $data );
+		fwrite( $handle, $data );
 		fclose( $handle );
 		clearstatcache();
 

--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -185,7 +185,6 @@ final class Cachify_HDD {
 	 */
 	private static function _create_file( $file, $data ) {
 		/* Writable? */
-
 		$handle = @fopen( $file, 'wb' );
 		if ( ! $handle ) {
 			trigger_error( esc_html( __METHOD__ . ": Could not write file {$file}.", E_USER_WARNING ) );

--- a/inc/class-cachify-memcached.php
+++ b/inc/class-cachify-memcached.php
@@ -132,8 +132,12 @@ final class Cachify_MEMCACHED {
 			return;
 		}
 
+		if ( ! self::$_memcached instanceof Memcached ) {
+			return;
+		}
+
 		/* Flush */
-		@self::$_memcached->flush();
+		self::$_memcached->flush();
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-up to #99. @angelocali and I looked at the remaining `@` in the code and identified two that can be removed. The other functions prefixed with the operator throw warnings in case of failure regarding to the docs, whatever that means.