### PR TITLE
Skip cache if request method not GET

### DIFF
--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1135,7 +1135,7 @@ final class Cachify {
 	 *
 	 * @since   0.2
 	 * @change  2.3.0
-	 * @change  2.4.0 Add check for sitemap feature.
+	 * @change  2.4.0 Add check for sitemap feature and skip cache for other request methods than GET.
 	 *
 	 * @return  boolean              TRUE on exclusion
 	 *
@@ -1147,7 +1147,7 @@ final class Cachify {
 		$options = self::$options;
 
 		/* Skip for all request methods except GET */
-		if ( $_SERVER['REQUEST_METHOD'] !== 'GET' ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return true;
 		}
 		if ( ! empty( $_GET ) && get_option( 'permalink_structure' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1146,8 +1146,8 @@ final class Cachify {
 		/* Plugin options */
 		$options = self::$options;
 
-		/* Request vars */
-		if ( ! empty( $_POST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		/* Skip for all request methods except GET */
+		if ( $_SERVER['REQUEST_METHOD'] !== 'GET' ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return true;
 		}
 		if ( ! empty( $_GET ) && get_option( 'permalink_structure' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/inc/setup/cachify.hdd.htaccess.php
+++ b/inc/setup/cachify.hdd.htaccess.php
@@ -35,7 +35,7 @@ $beginning = '# BEGIN CACHIFY
   &lt;/IfModule&gt;
 
   # Main Rules
-  RewriteCond %{REQUEST_METHOD} !=POST
+  RewriteCond %{REQUEST_METHOD} ="GET"
   RewriteCond %{QUERY_STRING} =""
   RewriteCond %{REQUEST_URI} !^/(wp-admin|wp-content/cache)/.*
   RewriteCond %{HTTP_COOKIE} !(wp-postpass|wordpress_logged_in|comment_author)_


### PR DESCRIPTION
This PR changes the `Cachify::_skip_cache()` method so that it returns `true` for all request methods that are not `GET`. Besides that, it adds a small modification to the `.htaccess` setup example, that fixes the check for the `REQUEST_METHOD`. We should add that to the changelog, so that users can modify their `.htaccess`.

Fixes #200 