### PR TITLE
Change the CondPattern used to check if the request method is GET

### DIFF
--- a/inc/setup/cachify.hdd.htaccess.php
+++ b/inc/setup/cachify.hdd.htaccess.php
@@ -26,7 +26,7 @@ $beginning = '# BEGIN CACHIFY
   RewriteRule .* - [E=CACHIFY_DIR:/]
 {{GZIP}}
   # Main Rules
-  RewriteCond %{REQUEST_METHOD} ="GET"
+  RewriteCond %{REQUEST_METHOD} GET
   RewriteCond %{QUERY_STRING} =""
   RewriteCond %{REQUEST_URI} !^/(wp-admin|wp-content/cache)/.*
   RewriteCond %{HTTP_COOKIE} !(wp-postpass|wordpress_logged_in|comment_author)_


### PR DESCRIPTION
It was brought to Florian‘s and my attention that the CondPattern used does not work properly and the cache is done via the PHP fallback. Therefore, I hereby submit my proposal for a change.

Let‘s assume a page that is cached on the hard disk. The proposal then fulfils the following conditions:
- A GET request delivers the cache directly via the Apache HTTP server, PHP is not used.
- All other request methods return an uncached result.

I was able to test it at netcup and for me it works with the change as desired. Please check the behaviour again with different hosts.