### PR TITLE
fix URL parsing for cache key generation (#275)

### DIFF
--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1074,7 +1074,7 @@ final class Cachify {
 
 		if ( empty( $url ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			$url = wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] );
+			$url = '//' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] );
 		}
 
 		$url_parts = wp_parse_url( $url );


### PR DESCRIPTION
As part of refactoring in #190 the URL parsing has been altered, s.t. we pass a concatenation of host and path to `wp_parse_url()`. This results in the actual host not being parsed at all which raises a PHP warning.

Prefix the URL with double slashes (the protocol is not of interest here) to fix the parsing.

We could use a full URL here, like
```php
$url = wp_unslash( $_SERVER['REQUEST_SCHEME'] ) '://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] );
```
or even add port, query, etc. to make it complete, but we only process host and path in the very next lines, so a reduced, protocol-agnostic URL is sufficient here.

resolves #275