### PR TITLE
move dark-mode styling into dashboard.css

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -5,6 +5,10 @@
 	fill: #606a73;
 }
 
+html.dark-mode body:not(.block-editor-page) #dashboard_right_now .cachify-icon {
+	fill: #bbc8d4;
+}
+
 #dashboard_right_now li a.cachify-glance::before {
 	content: "";
 	padding: 0;

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -155,8 +155,6 @@ final class Cachify {
 
 			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_dashboard_styles' ) );
 
-			add_action( 'doing_dark_mode', array( __CLASS__, 'admin_dashboard_dark_mode_styles' ) );
-
 			add_action( 'transition_comment_status', array( __CLASS__, 'touch_comment' ), 10, 3 );
 
 			add_action( 'edit_comment', array( __CLASS__, 'edit_comment' ) );
@@ -1608,6 +1606,8 @@ final class Cachify {
 	 * Fixing some admin dashboard styles
 	 *
 	 * @since 2.3.0
+	 *
+	 * @deprecated included in dashboard.css since 2.4
 	 */
 	public static function admin_dashboard_dark_mode_styles() {
 		wp_add_inline_style( 'cachify-dashboard', '#dashboard_right_now .cachify-icon use { fill: #bbc8d4; }' );


### PR DESCRIPTION
Dark mode styling has been added inline using the "doing_dark_mode" hook which is no longer called in current plugin versions.

Include the CSS definition directly into dashboard.css and deprecate the hook for adding inline styles.

----

resolves #264 

**However:** This does _not_ apply to all "dark-mode" plugins and not even to all themes, because the icon has two different shades of gray and is not affected by most stylings that assume Dashicons are used here. We might prefer a different approach like #277