### PR TITLE
clean up PHPdoc blocks

### DIFF
--- a/inc/class-cachify-apc.php
+++ b/inc/class-cachify-apc.php
@@ -16,10 +16,9 @@ final class Cachify_APC {
 	/**
 	 * Availability check
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @return bool TRUE when installed
 	 *
-	 * @return  boolean  true/false  TRUE when installed
+	 * @since 2.0.7
 	 */
 	public static function is_available() {
 		return extension_loaded( 'apc' );
@@ -28,10 +27,9 @@ final class Cachify_APC {
 	/**
 	 * Caching method as string
 	 *
-	 * @since   2.1.2
-	 * @change  2.1.2
+	 * @return string Caching method
 	 *
-	 * @return  string  Caching method
+	 * @since 2.1.2
 	 */
 	public static function stringify_method() {
 		return 'APC';
@@ -40,13 +38,13 @@ final class Cachify_APC {
 	/**
 	 * Store item in cache
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param string $hash       Hash of the entry.
+	 * @param string $data       Content of the entry.
+	 * @param int    $lifetime   Lifetime of the entry.
+	 * @param bool   $sig_detail Show details in signature.
 	 *
-	 * @param   string  $hash        Hash of the entry.
-	 * @param   string  $data        Content of the entry.
-	 * @param   integer $lifetime    Lifetime of the entry.
-	 * @param   bool    $sig_detail  Show details in signature.
+	 * @since 2.0
+	 * @since 2.3.0 added $sigDetail parameter
 	 */
 	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
 		/* Do not store empty data. */
@@ -66,11 +64,11 @@ final class Cachify_APC {
 	/**
 	 * Read item from cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $hash Hash of the entry.
 	 *
-	 * @param   string $hash  Hash of the entry.
-	 * @return  mixed         Content of the entry
+	 * @return mixed Content of the entry
+	 *
+	 * @since 2.0
 	 */
 	public static function get_item( $hash ) {
 		return ( function_exists( 'apc_exists' ) ? apc_exists( $hash ) : apc_fetch( $hash ) );
@@ -79,11 +77,10 @@ final class Cachify_APC {
 	/**
 	 * Delete item from cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $hash Hash of the entry.
+	 * @param string $url  URL of the entry [optional].
 	 *
-	 * @param   string $hash  Hash of the entry.
-	 * @param   string $url   URL of the entry [optional].
+	 * @since 2.0
 	 */
 	public static function delete_item( $hash, $url = '' ) {
 		apc_delete( $hash );
@@ -92,8 +89,7 @@ final class Cachify_APC {
 	/**
 	 * Clear the cache
 	 *
-	 * @since   2.0.0
-	 * @change  2.0.7
+	 * @since 2.0
 	 */
 	public static function clear_cache() {
 		if ( ! self::is_available() ) {
@@ -106,8 +102,7 @@ final class Cachify_APC {
 	/**
 	 * Print the cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @since 2.0
 	 */
 	public static function print_cache() {
 		return;
@@ -116,10 +111,9 @@ final class Cachify_APC {
 	/**
 	 * Get the cache size
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @return mixed Cache size
 	 *
-	 * @return  mixed  Cache size
+	 * @since 2.0
 	 */
 	public static function get_stats() {
 		/* Info */
@@ -136,11 +130,12 @@ final class Cachify_APC {
 	/**
 	 * Generate signature
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param bool $detail Show details in signature.
 	 *
-	 * @param   bool $detail  Show details in signature.
-	 * @return  string        Signature string
+	 * @return string Signature string
+	 *
+	 * @since 2.0
+	 * @since 2.3.0 added $detail parameter
 	 */
 	private static function _cache_signature( $detail ) {
 		return sprintf(

--- a/inc/class-cachify-cli.php
+++ b/inc/class-cachify-cli.php
@@ -16,11 +16,10 @@ final class Cachify_CLI {
 	/**
 	 * Flush Cache Callback
 	 *
-	 * @since   2.3.0
-	 * @change  2.3.0
-	 *
 	 * @param array $args the CLI arguments as array.
 	 * @param array $assoc_args the CLI arguments as associative array.
+	 *
+	 * @since 2.3.0
 	 */
 	public static function flush_cache( $args, $assoc_args ) {
 		// Set default arguments.
@@ -38,11 +37,10 @@ final class Cachify_CLI {
 	/**
 	 * Get cache size
 	 *
-	 * @since   2.3.0
-	 * @change  2.3.0
-	 *
 	 * @param array $args the CLI arguments as array.
 	 * @param array $assoc_args the CLI arguments as associative array.
+	 *
+	 * @since 2.3.0
 	 */
 	public static function get_cache_size( $args, $assoc_args ) {
 		// Set default arguments.
@@ -62,8 +60,7 @@ final class Cachify_CLI {
 	/**
 	 * Register CLI Commands
 	 *
-	 * @since   2.3.0
-	 * @change  2.3.0
+	 * @since 2.3.0
 	 */
 	public static function add_commands() {
 		// Add flush command.

--- a/inc/class-cachify-db.php
+++ b/inc/class-cachify-db.php
@@ -16,10 +16,9 @@ final class Cachify_DB {
 	/**
 	 * Availability check
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @return bool TRUE when installed
 	 *
-	 * @return  boolean  true/false  TRUE when installed
+	 * @since 2.0.7
 	 */
 	public static function is_available() {
 		return true;
@@ -28,10 +27,9 @@ final class Cachify_DB {
 	/**
 	 * Caching method as string
 	 *
-	 * @since   2.1.2
-	 * @change  2.1.2
+	 * @return string Caching method
 	 *
-	 * @return  string  Caching method
+	 * @since 2.1.2
 	 */
 	public static function stringify_method() {
 		return 'DB';
@@ -40,17 +38,17 @@ final class Cachify_DB {
 	/**
 	 * Store item in cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $hash     Hash of the entry.
+	 * @param string $data     Content of the entry.
+	 * @param int    $lifetime Lifetime of the entry.
 	 *
-	 * @param   string  $hash      Hash of the entry.
-	 * @param   string  $data      Content of the entry.
-	 * @param   integer $lifetime  Lifetime of the entry.
+	 * @since 2.0
 	 */
 	public static function store_item( $hash, $data, $lifetime ) {
 		/* Do not store empty data. */
 		if ( empty( $data ) ) {
 			trigger_error( __METHOD__ . ': Empty input.', E_USER_WARNING );
+
 			return;
 		}
 
@@ -73,11 +71,11 @@ final class Cachify_DB {
 	/**
 	 * Read item from cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $hash Hash of the entry.
 	 *
-	 * @param   string $hash    Hash of the entry.
-	 * @return  mixed           Content of the entry
+	 * @return mixed Content of the entry
+	 *
+	 * @since 2.0
 	 */
 	public static function get_item( $hash ) {
 		return get_transient( $hash );
@@ -86,11 +84,10 @@ final class Cachify_DB {
 	/**
 	 * Delete item from cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $hash Hash of the entry.
+	 * @param string $url  URL of the entry [optional].
 	 *
-	 * @param   string $hash  Hash of the entry.
-	 * @param   string $url   URL of the entry [optional].
+	 * @since 2.0
 	 */
 	public static function delete_item( $hash, $url = '' ) {
 		delete_transient( $hash );
@@ -99,8 +96,7 @@ final class Cachify_DB {
 	/**
 	 * Clear the cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @since 2.0
 	 */
 	public static function clear_cache() {
 		/* Init */
@@ -113,11 +109,11 @@ final class Cachify_DB {
 	/**
 	 * Print the cache
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param bool  $sig_detail Show details in signature.
+	 * @param array $cache      Array of cache values.
 	 *
-	 * @param   bool  $sig_detail  Show details in signature.
-	 * @param   array $cache       Array of cache values.
+	 * @since 2.0
+	 * @since 2.3.0 added $sig_detail parameter
 	 */
 	public static function print_cache( $sig_detail, $cache ) {
 		/* No array? */
@@ -141,16 +137,16 @@ final class Cachify_DB {
 	/**
 	 * Get the cache size
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @return int Column size
 	 *
-	 * @return  integer  Column size
+	 * @since 2.0
 	 */
 	public static function get_stats() {
 		/* Init */
 		global $wpdb;
 
 		/* Read */
+
 		return $wpdb->get_var(
 			'SELECT SUM( CHAR_LENGTH(option_value) ) FROM `' . $wpdb->options . "` WHERE `option_name` LIKE ('\_transient%.cachify')"
 		);
@@ -159,12 +155,13 @@ final class Cachify_DB {
 	/**
 	 * Generate signature
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param bool  $detail Show details in signature.
+	 * @param array $meta   Content of metadata.
 	 *
-	 * @param   bool  $detail  Show details in signature.
-	 * @param   array $meta    Content of metadata.
-	 * @return  string         Signature string
+	 * @return string Signature string
+	 *
+	 * @since 2.0
+	 * @since 2.3.0 added $detail parameter
 	 */
 	private static function _cache_signature( $detail, $meta ) {
 		/* No array? */
@@ -210,10 +207,9 @@ final class Cachify_DB {
 	/**
 	 * Return query count
 	 *
-	 * @since   0.1
-	 * @change  2.0
+	 * @return int Number of queries
 	 *
-	 * @return  integer  Number of queries
+	 * @since 0.1
 	 */
 	private static function _page_queries() {
 		return $GLOBALS['wpdb']->num_queries;
@@ -222,10 +218,9 @@ final class Cachify_DB {
 	/**
 	 * Return execution time
 	 *
-	 * @since   0.1
-	 * @change  2.0
+	 * @return int Execution time in seconds
 	 *
-	 * @return  integer  Execution time in seconds
+	 * @since 0.1
 	 */
 	private static function _page_timer() {
 		return timer_stop( 0, 2 );
@@ -234,10 +229,9 @@ final class Cachify_DB {
 	/**
 	 * Return memory consumption
 	 *
-	 * @since   0.7
-	 * @change  2.0
+	 * @return string Formatted memory size
 	 *
-	 * @return  string  Formatted memory size
+	 * @since 0.7
 	 */
 	private static function _page_memory() {
 		return ( function_exists( 'memory_get_usage' ) ? size_format( memory_get_usage(), 2 ) : 0 );

--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -16,10 +16,9 @@ final class Cachify_HDD {
 	/**
 	 * Availability check
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @return bool TRUE when installed
 	 *
-	 * @return  boolean  true/false  TRUE when installed
+	 * @since 2.0.7
 	 */
 	public static function is_available() {
 		$option = get_option( 'permalink_structure' );
@@ -29,9 +28,9 @@ final class Cachify_HDD {
 	/**
 	 * Returns if gzip file creation is enabled
 	 *
-	 * @since  2.4.0
-	 *
 	 * @return bool
+	 *
+	 * @since 2.4.0
 	 */
 	public static function is_gzip_enabled() {
 		/**
@@ -45,10 +44,9 @@ final class Cachify_HDD {
 	/**
 	 * Caching method as string
 	 *
-	 * @since   2.1.2
-	 * @change  2.1.2
+	 * @return string Caching method
 	 *
-	 * @return  string  Caching method
+	 * @since 2.1.2
 	 */
 	public static function stringify_method() {
 		return 'HDD';
@@ -57,13 +55,13 @@ final class Cachify_HDD {
 	/**
 	 * Store item in cache
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param string $hash       Hash  of the entry [ignored].
+	 * @param string $data       Content of the entry.
+	 * @param int    $lifetime   Lifetime of the entry [ignored].
+	 * @param bool   $sig_detail Show details in signature.
 	 *
-	 * @param   string  $hash        Hash  of the entry [ignored].
-	 * @param   string  $data        Content of the entry.
-	 * @param   integer $lifetime    Lifetime of the entry [ignored].
-	 * @param   bool    $sig_detail  Show details in signature.
+	 * @since 2.0
+	 * @since 2.3.0 added $sig_details parameter
 	 */
 	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
 		/* Do not store empty data. */
@@ -81,10 +79,9 @@ final class Cachify_HDD {
 	/**
 	 * Read item from cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @return bool True if cache is present.
 	 *
-	 * @return  boolean  True if cache is present.
+	 * @since 2.0
 	 */
 	public static function get_item() {
 		return is_readable(
@@ -95,11 +92,10 @@ final class Cachify_HDD {
 	/**
 	 * Delete item from cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $hash Hash of the entry [ignored].
+	 * @param string $url  URL of the entry.
 	 *
-	 * @param   string $hash  Hash of the entry [ignored].
-	 * @param   string $url   URL of the entry.
+	 * @since 2.0
 	 */
 	public static function delete_item( $hash, $url ) {
 		self::_clear_dir(
@@ -110,8 +106,7 @@ final class Cachify_HDD {
 	/**
 	 * Clear the cache
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @since 2.0
 	 */
 	public static function clear_cache() {
 		self::_clear_dir(
@@ -123,8 +118,7 @@ final class Cachify_HDD {
 	/**
 	 * Print the cache
 	 *
-	 * @since   2.0
-	 * @change  2.3
+	 * @since 2.0
 	 */
 	public static function print_cache() {
 		$filename = self::_file_html();
@@ -138,10 +132,9 @@ final class Cachify_HDD {
 	/**
 	 * Get the cache size
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @return int Directory size
 	 *
-	 * @return  integer  Directory size
+	 * @since 2.0
 	 */
 	public static function get_stats() {
 		return self::_dir_size( CACHIFY_CACHE_DIR );
@@ -150,11 +143,12 @@ final class Cachify_HDD {
 	/**
 	 * Generate signature
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param bool $detail Show details in signature.
 	 *
-	 * @param   bool $detail  Show details in signature.
-	 * @return  string        Signature string
+	 * @return string Signature string
+	 *
+	 * @since 2.0
+	 * @since 2.3.0 added $detail parameter
 	 */
 	private static function _cache_signature( $detail ) {
 		return sprintf(
@@ -171,10 +165,9 @@ final class Cachify_HDD {
 	/**
 	 * Initialize caching process
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $data Cache content.
 	 *
-	 * @param   string $data  Cache content.
+	 * @since 2.0
 	 */
 	private static function _create_files( $data ) {
 		$file_path = self::_file_path();
@@ -200,11 +193,10 @@ final class Cachify_HDD {
 	/**
 	 * Create cache file
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $file Path to cache file.
+	 * @param string $data Cache content.
 	 *
-	 * @param   string $file  Path to cache file.
-	 * @param   string $data  Cache content.
+	 * @since 2.0
 	 */
 	private static function _create_file( $file, $data ) {
 		/* Writable? */
@@ -230,11 +222,10 @@ final class Cachify_HDD {
 	/**
 	 * Clear directory
 	 *
-	 * @since   2.0
-	 * @change  2.0.5
+	 * @param string $dir       Directory path.
+	 * @param bool   $recursive true for clearing subdirectories as well.
 	 *
-	 * @param   string  $dir        Directory path.
-	 * @param   boolean $recursive  true for clearing subdirectories as well.
+	 * @since 2.0
 	 */
 	private static function _clear_dir( $dir, $recursive = false ) {
 		/* Remote training slash */
@@ -285,11 +276,11 @@ final class Cachify_HDD {
 	/**
 	 * Get directory size
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $dir Directory path.
 	 *
-	 * @param   string $dir   Directory path.
-	 * @return  mixed         Directory size
+	 * @return mixed Directory size
+	 *
+	 * @since 2.0
 	 */
 	public static function _dir_size( $dir = '.' ) {
 		/* Is directory? */
@@ -330,11 +321,11 @@ final class Cachify_HDD {
 	/**
 	 * Path to cache file
 	 *
-	 * @since   2.0
-	 * @change  2.0
+	 * @param string $path Request URI or permalink [optional].
 	 *
-	 * @param   string $path  Request URI or permalink [optional].
-	 * @return  string        Path to cache file
+	 * @return string Path to cache file
+	 *
+	 * @since 2.0
 	 */
 	private static function _file_path( $path = null ) {
 		$prefix = is_ssl() ? 'https-' : '';
@@ -362,11 +353,11 @@ final class Cachify_HDD {
 	/**
 	 * Path to HTML file
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param string $file_path File path [optional].
 	 *
-	 * @param   string $file_path   File path [optional].
-	 * @return  string              Path to HTML file
+	 * @return string Path to HTML file
+	 *
+	 * @since 2.0
 	 */
 	private static function _file_html( $file_path = '' ) {
 		return ( empty( $file_path ) ? self::_file_path() : $file_path ) . 'index.html';
@@ -375,11 +366,11 @@ final class Cachify_HDD {
 	/**
 	 * Path to GZIP file
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @param string $file_path File path [optional].
 	 *
-	 * @param   string $file_path   File path [optional].
-	 * @return  string              Path to GZIP file
+	 * @return string Path to GZIP file
+	 *
+	 * @since 2.0
 	 */
 	private static function _file_gzip( $file_path = '' ) {
 		return ( empty( $file_path ) ? self::_file_path() : $file_path ) . 'index.html.gz';
@@ -447,6 +438,5 @@ final class Cachify_HDD {
 		}
 
 		return true;
-
 	}
 }

--- a/inc/class-cachify-memcached.php
+++ b/inc/class-cachify-memcached.php
@@ -16,18 +16,18 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Memcached-Object
 	 *
-	 * @since  2.0.7
-	 * @var    object
+	 * @var object
+	 *
+	 * @since 2.0.7
 	 */
 	private static $_memcached;
 
 	/**
 	 * Availability check
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @return bool TRUE when installed
 	 *
-	 * @return  boolean  true/false  TRUE when installed
+	 * @since 2.0.7
 	 */
 	public static function is_available() {
 		return class_exists( 'Memcached' )
@@ -38,10 +38,9 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Caching method as string
 	 *
-	 * @since   2.1.2
-	 * @change  2.1.2
+	 * @return string Caching method
 	 *
-	 * @return  string  Caching method
+	 * @since 2.1.2
 	 */
 	public static function stringify_method() {
 		return 'Memcached';
@@ -50,13 +49,13 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Store item in cache
 	 *
-	 * @param   string  $hash       Hash of the entry [ignored].
-	 * @param   string  $data       Content of the entry.
-	 * @param   integer $lifetime   Lifetime of the entry.
-	 * @param   bool    $sig_detail  Show details in signature.
+	 * @param string $hash       Hash of the entry [ignored].
+	 * @param string $data       Content of the entry.
+	 * @param int    $lifetime   Lifetime of the entry.
+	 * @param bool   $sig_detail Show details in signature.
 	 *
-	 * @since   2.0.7
-	 * @change  2.3.0
+	 * @since 2.0.7
+	 * @since 2.3.0 added $sig_detail parameter
 	 */
 	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
 		/* Do not store empty data. */
@@ -81,11 +80,11 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Read item from cache
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @param string $hash Hash of the entry.
 	 *
-	 * @param   string $hash  Hash of the entry.
-	 * @return  mixed         Content of the entry
+	 * @return mixed Content of the entry
+	 *
+	 * @since 2.0.7
 	 */
 	public static function get_item( $hash ) {
 		/* Server connect */
@@ -102,11 +101,10 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Delete item from cache
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @param string $hash Hash of the entry.
+	 * @param string $url  URL of the entry [optional].
 	 *
-	 * @param   string $hash  Hash of the entry.
-	 * @param   string $url   URL of the entry [optional].
+	 * @since 2.0.7
 	 */
 	public static function delete_item( $hash, $url = '' ) {
 		/* Server connect */
@@ -123,8 +121,7 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Clear the cache
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @since 2.0.7
 	 */
 	public static function clear_cache() {
 		/* Server connect */
@@ -143,8 +140,7 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Print the cache
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @since 2.0.7
 	 */
 	public static function print_cache() {
 		return;
@@ -153,10 +149,9 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Get the cache size
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @return mixed Cache size
 	 *
-	 * @return  mixed  Cache size
+	 * @since 2.0.7
 	 */
 	public static function get_stats() {
 		/* Server connect */
@@ -186,11 +181,12 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Generate signature
 	 *
-	 * @since   2.0.7
-	 * @change  2.3.0
+	 * @param bool $detail Show details in signature.
 	 *
-	 * @param   bool $detail  Show details in signature.
-	 * @return  string        Signature string
+	 * @return string Signature string
+	 *
+	 * @since 2.0.7
+	 * @since 2.3.0 added $detail parameter
 	 */
 	private static function _cache_signature( $detail ) {
 		return sprintf(
@@ -207,11 +203,11 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Path of cache file
 	 *
-	 * @since   2.0.7
-	 * @change  2.0.7
+	 * @param string $path Request URI or permalink [optional].
 	 *
-	 * @param   string $path  Request URI or permalink [optional].
-	 * @return  string        Path to cache file
+	 * @return string Path to cache file
+	 *
+	 * @since 2.0.7
 	 */
 	private static function _file_path( $path = null ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
@@ -230,12 +226,11 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Connect to Memcached server
 	 *
-	 * @since   2.0.7
-	 * @change  2.1.8
+	 * @hook  array  cachify_memcached_servers  Array with memcached servers
 	 *
-	 * @hook    array  cachify_memcached_servers  Array with memcached servers
+	 * @return bool TRUE on success
 	 *
-	 * @return  boolean  true/false  TRUE on success
+	 * @since 2.0.7
 	 */
 	private static function _connect_server() {
 		/* Not enabled? */

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -16,32 +16,36 @@ final class Cachify {
 	/**
 	 * Plugin options
 	 *
-	 * @since  2.0
-	 * @var    array
+	 * @var array
+	 *
+	 * @since 2.0
 	 */
 	private static $options;
 
 	/**
 	 * Caching method
 	 *
-	 * @since  2.0
-	 * @var    object
+	 * @var object
+	 *
+	 * @since 2.0
 	 */
 	private static $method;
 
 	/**
-	 * Whether we are on an Nginx server or not.
+	 * Whether we are on a Nginx server or not.
+	 *
+	 * @var bool
 	 *
 	 * @since 2.2.5
-	 * @var   boolean
 	 */
 	private static $is_nginx;
 
 	/**
 	 * Method settings
 	 *
-	 * @since  2.0.9
-	 * @var    integer
+	 * @var int
+	 *
+	 * @since 2.0.9
 	 */
 	const METHOD_DB = 0;
 	const METHOD_APC = 1;
@@ -51,8 +55,9 @@ final class Cachify {
 	/**
 	 * Minify settings
 	 *
-	 * @since  2.0.9
-	 * @var    integer
+	 * @var int
+	 *
+	 * @since 2.0.9
 	 */
 	const MINIFY_DISABLED = 0;
 	const MINIFY_HTML_ONLY = 1;
@@ -61,7 +66,7 @@ final class Cachify {
 	/**
 	 * REST endpoints
 	 *
-	 * @var    string
+	 * @var string
 	 */
 	const REST_NAMESPACE = 'cachify/v1';
 	const REST_ROUTE_FLUSH = 'flush';
@@ -69,8 +74,7 @@ final class Cachify {
 	/**
 	 * Pseudo constructor
 	 *
-	 * @since   2.0.5
-	 * @change  2.0.5
+	 * @since 2.0.5
 	 */
 	public static function instance() {
 		new self();
@@ -79,10 +83,7 @@ final class Cachify {
 	/**
 	 * Constructor
 	 *
-	 * @since   1.0.0
-	 * @change  2.2.2
-	 *
-	 * @return  void
+	 * @since 1.0
 	 */
 	public function __construct() {
 		/* Set defaults */
@@ -177,8 +178,7 @@ final class Cachify {
 	/**
 	 * Deactivation hook
 	 *
-	 * @since   2.1.0
-	 * @change  2.1.0
+	 * @since 2.1.0
 	 */
 	public static function on_deactivation() {
 		/* Remove hdd cache cron when hdd is selected */
@@ -195,8 +195,7 @@ final class Cachify {
 	/**
 	 * Activation hook
 	 *
-	 * @since   1.0
-	 * @change  2.1.0
+	 * @since 1.0
 	 */
 	public static function on_activation() {
 		/* Multisite & Network */
@@ -221,10 +220,10 @@ final class Cachify {
 	/**
 	 * Plugin installation on new WPMS site.
 	 *
-	 * @since 1.0
-	 * @since 2.4 supports WP_Site argument
-	 *
 	 * @param int|WP_Site $new_site New site ID or object.
+	 *
+	 * @since 1.0
+	 * @since 2.4.0 supports WP_Site argument
 	 */
 	public static function install_later( $new_site ) {
 		/* No network plugin */
@@ -245,8 +244,7 @@ final class Cachify {
 	/**
 	 * Actual installation of the options
 	 *
-	 * @since   1.0
-	 * @change  2.0
+	 * @since 1.0
 	 */
 	private static function _install_backend() {
 		add_option(
@@ -261,8 +259,7 @@ final class Cachify {
 	/**
 	 * Uninstalling of the plugin per MU blog.
 	 *
-	 * @since   1.0
-	 * @change  2.1.0
+	 * @since 1.0
 	 */
 	public static function on_uninstall() {
 		/* Global */
@@ -292,10 +289,10 @@ final class Cachify {
 	/**
 	 * Uninstalling of the plugin for WPMS site.
 	 *
-	 * @since 1.0
-	 * @since 2.4 supports WP_Site argument
-	 *
 	 * @param int|WP_Site $old_site Old site ID or object.
+	 *
+	 * @since 1.0
+	 * @since 2.4.0 supports WP_Site argument
 	 */
 	public static function uninstall_later( $old_site ) {
 		/* No network plugin */
@@ -316,8 +313,7 @@ final class Cachify {
 	/**
 	 * Actual uninstalling of the plugin
 	 *
-	 * @since   1.0
-	 * @change  1.0
+	 * @since 1.0
 	 */
 	private static function _uninstall_backend() {
 		/* Option */
@@ -330,10 +326,9 @@ final class Cachify {
 	/**
 	 * Get IDs of installed blogs
 	 *
-	 * @since   1.0
-	 * @change  1.0
+	 * @return array Blog IDs
 	 *
-	 * @return  array  Blog IDs
+	 * @since 1.0
 	 */
 	private static function _get_blog_ids() {
 		/* Global */
@@ -384,8 +379,7 @@ final class Cachify {
 	/**
 	 * Register the language file
 	 *
-	 * @since   2.1.3
-	 * @change  2.3.2
+	 * @since 2.1.3
 	 */
 	public static function register_textdomain() {
 		load_plugin_textdomain( 'cachify' );
@@ -394,8 +388,7 @@ final class Cachify {
 	/**
 	 * Set default options
 	 *
-	 * @since   2.0
-	 * @change  2.0.7
+	 * @since 2.0
 	 */
 	private static function _set_default_vars() {
 		/* Options */
@@ -422,10 +415,9 @@ final class Cachify {
 	/**
 	 * Get options
 	 *
-	 * @since   2.0
-	 * @change  2.3.0
+	 * @return array Array of option values
 	 *
-	 * @return  array  Array of option values
+	 * @since 2.0
 	 */
 	private static function _get_options() {
 		return wp_parse_args(
@@ -449,7 +441,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 * @since 2.1.9
-	 * @since 2.4   Removed $data parameter and return value.
+	 * @since 2.4.0 Removed $data parameter and return value.
 	 */
 	public static function robots_txt() {
 		/* HDD only */
@@ -461,7 +453,7 @@ final class Cachify {
 	/**
 	 * HDD Cache expiration cron action.
 	 *
-	 * @since 2.4
+	 * @since 2.4.0
 	 */
 	public static function run_hdd_cache_cron() {
 		Cachify_HDD::clear_cache();
@@ -474,7 +466,7 @@ final class Cachify {
 	 *
 	 * @return array Array of non-default schedules with our tasks added.
 	 *
-	 * @since 2.4
+	 * @since 2.4.0
 	 */
 	public static function add_cron_cache_expiration( $schedules ) {
 		$schedules['cachify_cache_expire'] = array(
@@ -487,11 +479,11 @@ final class Cachify {
 	/**
 	 * Add the action links
 	 *
-	 * @since   1.0
-	 * @change  1.0
+	 * @param array $data Initial array with action links.
 	 *
-	 * @param   array $data  Initial array with action links.
-	 * @return  array        Merged array with action links.
+	 * @return array Merged array with action links.
+	 *
+	 * @since 1.0
 	 */
 	public static function action_links( $data ) {
 		/* Permissions? */
@@ -519,12 +511,12 @@ final class Cachify {
 	/**
 	 * Meta links of the plugin
 	 *
-	 * @since   0.5
-	 * @change  2.0.5
+	 * @param array  $input Initial array with meta links.
+	 * @param string $page  Current page.
 	 *
-	 * @param   array  $input  Initial array with meta links.
-	 * @param   string $page   Current page.
-	 * @return  array          Merged array with meta links.
+	 * @return array Merged array with meta links.
+	 *
+	 * @since 0.5
 	 */
 	public static function row_meta( $input, $page ) {
 		/* Permissions */
@@ -544,11 +536,11 @@ final class Cachify {
 	/**
 	 * Add cache properties to dashboard
 	 *
-	 * @since   2.0.0
-	 * @change  2.2.2
+	 * @param array $items Initial array with dashboard items.
 	 *
-	 * @param   array $items  Initial array with dashboard items.
-	 * @return  array         Merged array with dashboard items.
+	 * @return array Merged array with dashboard items.
+	 *
+	 * @since 2.0.0
 	 */
 	public static function add_dashboard_count( $items = array() ) {
 		/* Skip */
@@ -601,10 +593,9 @@ final class Cachify {
 	/**
 	 * Get the cache size
 	 *
-	 * @since   2.0.6
-	 * @change  2.0.6
+	 * @return int Cache size in bytes.
 	 *
-	 * @return  integer    Cache size in bytes.
+	 * @since 2.0.6
 	 */
 	public static function get_cache_size() {
 		$size = get_transient( 'cachify_cache_size' );
@@ -631,13 +622,13 @@ final class Cachify {
 	/**
 	 * Add flush icon to admin bar menu
 	 *
-	 * @since   1.2
-	 * @change  2.2.2
-	 * @change  2.4.0 Adjust icon for flush request via AJAX
+	 * @hook    mixed cachify_user_can_flush_cache
 	 *
-	 * @hook    mixed   cachify_user_can_flush_cache
+	 * @param object $wp_admin_bar Object of menu items.
 	 *
-	 * @param   object $wp_admin_bar  Object of menu items.
+	 * @since 1.2
+	 * @since 2.2.2
+	 * @since 2.4.0 Adjust icon for flush request via AJAX
 	 */
 	public static function add_flush_icon( $wp_admin_bar ) {
 		/* Quit */
@@ -679,9 +670,9 @@ final class Cachify {
 	/**
 	 * Returns the dashicon class for the success state in admin bar flush button
 	 *
-	 * @since  2.4.0
-	 *
 	 * @return string
+	 *
+	 * @since 2.4.0
 	 */
 	public static function get_dashicon_success_class() {
 		global $wp_version;
@@ -695,11 +686,11 @@ final class Cachify {
 	/**
 	 * Add a script to query the REST endpoint and animate the flush icon in admin bar menu
 	 *
-	 * @since   2.4.0
+	 * @hook  mixed  cachify_user_can_flush_cache ?
 	 *
-	 * @hook    mixed   cachify_user_can_flush_cache ?
+	 * @param object $wp_admin_bar Object of menu items.
 	 *
-	 * @param   object $wp_admin_bar  Object of menu items.
+	 * @since 2.4.0
 	 */
 	public static function add_flush_icon_script( $wp_admin_bar ) {
 		/* Quit */
@@ -728,7 +719,7 @@ final class Cachify {
 	/**
 	 * Registers an REST endpoint for the flush operation
 	 *
-	 * @change 2.4.0
+	 * @since 2.4.0
 	 */
 	public static function add_flush_rest_endpoint() {
 		register_rest_route(
@@ -751,9 +742,9 @@ final class Cachify {
 	/**
 	 * Check if user can manage options
 	 *
-	 * @since   2.4.0
+	 * @return bool
 	 *
-	 * @return  bool
+	 * @since 2.4.0
 	 */
 	public static function user_can_manage_options() {
 		return current_user_can( 'manage_options' );
@@ -762,13 +753,13 @@ final class Cachify {
 	/**
 	 * Process plugin's meta actions
 	 *
-	 * @since   0.5
-	 * @change  2.2.2
-	 * @change  2.4.0  Extract cache flushing to own method and always redirect to referer with new value for `_cachify` param.
-	 *
 	 * @hook    mixed  cachify_user_can_flush_cache
 	 *
-	 * @param   array $data  Metadata of the plugin.
+	 * @param array $data Metadata of the plugin.
+	 *
+	 * @since 0.5
+	 * @since 2.2.2
+	 * @since 2.4.0  Extract cache flushing to own method and always redirect to referer with new value for `_cachify` param.
 	 */
 	public static function process_flush_request( $data ) {
 		/* Skip if not a flush request */
@@ -865,10 +856,10 @@ final class Cachify {
 	/**
 	 * Notice after successful flushing of the cache
 	 *
-	 * @since   1.2
-	 * @change  2.2.2
+	 * @hook  mixed  cachify_user_can_flush_cache
 	 *
-	 * @hook    mixed  cachify_user_can_flush_cache
+	 * @since 1.2
+	 * @since 2.2.2
 	 */
 	public static function flush_notice() {
 		/* No admin */
@@ -885,10 +876,10 @@ final class Cachify {
 	/**
 	 * Remove page from cache or flush on comment edit
 	 *
-	 * @since   0.1.0
-	 * @change  2.1.2
+	 * @param int $id Comment ID.
 	 *
-	 * @param   integer $id  Comment ID.
+	 * @since 0.1.0
+	 * @since 2.1.2
 	 */
 	public static function edit_comment( $id ) {
 		if ( self::$options['reset_on_comment'] ) {
@@ -903,12 +894,13 @@ final class Cachify {
 	/**
 	 * Remove page from cache or flush on new comment
 	 *
-	 * @since   0.1.0
-	 * @change  2.1.2
+	 * @param mixed $approved Comment status.
+	 * @param array $comment  Array of properties.
 	 *
-	 * @param   mixed $approved  Comment status.
-	 * @param   array $comment   Array of properties.
-	 * @return  mixed            Comment status.
+	 * @return mixed Comment status.
+	 *
+	 * @since 0.1
+	 * @since 2.1.2
 	 */
 	public static function pre_comment( $approved, $comment ) {
 		/* Approved comment? */
@@ -926,12 +918,12 @@ final class Cachify {
 	/**
 	 * Remove page from cache or flush on comment edit
 	 *
-	 * @since   0.1
-	 * @change  2.1.2
+	 * @param string $new_status New status.
+	 * @param string $old_status Old status.
+	 * @param object $comment    The comment.
 	 *
-	 * @param   string $new_status  New status.
-	 * @param   string $old_status  Old status.
-	 * @param   object $comment     The comment.
+	 * @since 0.1
+	 * @since 2.1.2
 	 */
 	public static function touch_comment( $new_status, $old_status, $comment ) {
 		if ( $new_status !== $old_status ) {
@@ -946,8 +938,8 @@ final class Cachify {
 	/**
 	 * Generate publish hook for custom post types
 	 *
-	 * @since   2.1.7  Make the function public
-	 * @since   2.0.3
+	 * @since 2.0.3
+	 * @since 2.1.7  Make the function public
 	 *
 	 * @deprecated no longer used since 2.4
 	 */
@@ -974,11 +966,10 @@ final class Cachify {
 	/**
 	 * Removes the post type cache on post updates
 	 *
-	 * @since   2.0.3
-	 * @change  2.3.0
+	 * @param int    $post_id Post ID.
+	 * @param object $post    Post object.
 	 *
-	 * @param   integer $post_id  Post ID.
-	 * @param   object  $post     Post object.
+	 * @since 2.0.3
 	 *
 	 * @deprecated no longer used since 2.4
 	 */
@@ -1009,11 +1000,11 @@ final class Cachify {
 	/**
 	 * Removes the post type cache if saved or updated
 	 *
+	 * @param int $id Post ID.
+	 *
 	 * @since 2.0.3
 	 * @since 2.1.7 Make the function public.
-	 * @since 2.4   Renamed to save_update_trash_post with $id parameter.
-	 *
-	 * @param integer $id Post ID.
+	 * @since 2.4.0 Renamed to save_update_trash_post with $id parameter.
 	 */
 	public static function save_update_trash_post( $id ) {
 		$status = get_post_status( $id );
@@ -1027,12 +1018,12 @@ final class Cachify {
 	/**
 	 * Removes the post type cache before an existing post type is updated in the db
 	 *
+	 * @param int   $id   Post ID.
+	 * @param array $data Post data.
+	 *
 	 * @since 2.0.3
 	 * @since 2.3.0
-	 * @since 2.4   Renamed to post_update.
-	 *
-	 * @param integer $id   Post ID.
-	 * @param array   $data Post data.
+	 * @since 2.4.0 Renamed to post_update.
 	 */
 	public static function post_update( $id, $data ) {
 		$new_status = $data['post_status'];
@@ -1047,9 +1038,9 @@ final class Cachify {
 	/**
 	 * Clear cache when any post type has been created or updated
 	 *
-	 * @since 2.4
+	 * @param int|WP_Post $post Post ID or object.
 	 *
-	 * @param integer|WP_Post $post Post ID or object.
+	 * @since 2.4.0
 	 */
 	public static function flush_cache_for_posts( $post ) {
 		if ( is_int( $post ) ) {
@@ -1076,9 +1067,9 @@ final class Cachify {
 	/**
 	 * Flush post cache on WooCommerce stock changes.
 	 *
-	 * @since 2.4
-	 *
 	 * @param int|WC_Product $product Product ID or object.
+	 *
+	 * @since 2.4.0
 	 */
 	public static function flush_woocommerce( $product ) {
 		if ( is_int( $product ) ) {
@@ -1093,10 +1084,9 @@ final class Cachify {
 	/**
 	 * Removes a page (id) from cache
 	 *
-	 * @since   2.0.3
-	 * @change  2.1.3
+	 * @param int $post_id Post ID.
 	 *
-	 * @param   integer $post_id  Post ID.
+	 * @since 2.0.3
 	 */
 	public static function remove_page_cache_by_post_id( $post_id ) {
 		$post_id = (int) $post_id;
@@ -1110,10 +1100,9 @@ final class Cachify {
 	/**
 	 * Removes a page url from cache
 	 *
-	 * @since   0.1
-	 * @change  2.1.3
+	 * @param string $url Page URL.
 	 *
-	 * @param  string $url  Page URL.
+	 * @since 0.1
 	 */
 	public static function remove_page_cache_by_url( $url ) {
 		$url = (string) $url;
@@ -1134,10 +1123,9 @@ final class Cachify {
 	/**
 	 * Get cache validity
 	 *
-	 * @since   2.0.0
-	 * @change  2.1.7
+	 * @return int Validity period in seconds.
 	 *
-	 * @return  integer    Validity period in seconds.
+	 * @since 2.0.0
 	 */
 	private static function _cache_expires() {
 		return HOUR_IN_SECONDS * self::$options['cache_expires'];
@@ -1146,9 +1134,9 @@ final class Cachify {
 	/**
 	 * Determine if cache details should be printed in signature
 	 *
-	 * @since   2.3.0
+	 * @return bool Show details in signature.
 	 *
-	 * @return  bool  Show details in signature.
+	 * @since 2.3.0
 	 */
 	private static function _signature_details() {
 		return 1 === self::$options['sig_detail'];
@@ -1157,12 +1145,12 @@ final class Cachify {
 	/**
 	 * Get hash value for caching
 	 *
-	 * @since   0.1
-	 * @change  2.0
-	 * @change  2.4.0 Fix issue with port in URL.
+	 * @param string $url URL to hash [optional].
 	 *
-	 * @param   string $url  URL to hash [optional].
-	 * @return  string       Cachify hash value.
+	 * @return string Cachify hash value.
+	 *
+	 * @since 0.1
+	 * @since 2.0
 	 */
 	private static function _cache_hash( $url = '' ) {
 		$prefix = is_ssl() ? 'https-' : '';
@@ -1180,11 +1168,12 @@ final class Cachify {
 	/**
 	 * Split by comma
 	 *
-	 * @since   0.9.1
-	 * @change  1.0
+	 * @param string $input String to split.
 	 *
-	 * @param   string $input  String to split.
-	 * @return  array          Splitted values.
+	 * @return array Splitted values.
+	 *
+	 * @since 0.9.1
+	 * @since 1.0
 	 */
 	private static function _preg_split( $input ) {
 		return (array) preg_split( '/,/', $input, -1, PREG_SPLIT_NO_EMPTY );
@@ -1193,10 +1182,9 @@ final class Cachify {
 	/**
 	 * Check for index page
 	 *
-	 * @since   0.6
-	 * @change  1.0
+	 * @return bool TRUE if index
 	 *
-	 * @return  boolean  TRUE if index
+	 * @since 0.6
 	 */
 	private static function _is_index() {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
@@ -1206,10 +1194,9 @@ final class Cachify {
 	/**
 	 * Check for mobile devices
 	 *
-	 * @since   0.9.1
-	 * @change  2.3.0
+	 * @return bool TRUE if mobile
 	 *
-	 * @return  boolean  TRUE if mobile
+	 * @since 0.9.1
 	 */
 	private static function _is_mobile() {
 		$templatedir = get_template_directory();
@@ -1219,10 +1206,9 @@ final class Cachify {
 	/**
 	 * Check if user is logged in or marked
 	 *
-	 * @since   2.0.0
-	 * @change  2.0.5
+	 * @return bool TRUE on "marked" users
 	 *
-	 * @return  boolean  $diff  TRUE on "marked" users
+	 * @since 2.0.0
 	 */
 	private static function _is_logged_in() {
 		/* Logged in */
@@ -1248,7 +1234,7 @@ final class Cachify {
 	/**
 	 * Register all hooks to flush the total cache
 	 *
-	 * @since   2.4.0
+	 * @since 2.4.0
 	 */
 	public static function register_flush_cache_hooks() {
 		/* Define all default flush cache hooks */
@@ -1280,13 +1266,11 @@ final class Cachify {
 	/**
 	 * Define exclusions for caching
 	 *
-	 * @since   0.2
-	 * @change  2.3.0
-	 * @change  2.4.0 Add check for sitemap feature and skip cache for other request methods than GET.
+	 * @hook bool cachify_skip_cache
 	 *
-	 * @return  boolean              TRUE on exclusion
+	 * @return bool TRUE on exclusion
 	 *
-	 * @hook    boolean  cachify_skip_cache
+	 * @since 0.2
 	 */
 	private static function _skip_cache() {
 
@@ -1361,13 +1345,13 @@ final class Cachify {
 	/**
 	 * Minify HTML code
 	 *
-	 * @since   0.9.2
-	 * @change  2.0.9
+	 * @hook  array cachify_minify_ignore_tags
 	 *
-	 * @param   string $data  Original HTML code.
-	 * @return  string        Minified code
+	 * @param string $data Original HTML code.
 	 *
-	 * @hook    array   cachify_minify_ignore_tags
+	 * @return string Minified code
+	 *
+	 * @since 0.9.2
 	 */
 	private static function _minify_cache( $data ) {
 		/* Disabled? */
@@ -1426,11 +1410,10 @@ final class Cachify {
 	/**
 	 * Flush total cache
 	 *
-	 * @since   0.1
-	 * @change  2.0
-	 * @change  2.4.0 Do not flush cache for post revisions.
+	 * @param bool $clear_all_methods Flush all caching methods (default: FALSE).
 	 *
-	 * @param bool $clear_all_methods  Flush all caching methods (default: FALSE).
+	 * @since 0.1
+	 * @since 2.0
 	 */
 	public static function flush_total_cache( $clear_all_methods = false ) {
 		// We do not need to flush the cache for saved post revisions.
@@ -1466,11 +1449,12 @@ final class Cachify {
 	/**
 	 * Assign the cache
 	 *
-	 * @since   0.1
-	 * @change  2.0
+	 * @param string $data Content of the page.
 	 *
-	 * @param   string $data  Content of the page.
-	 * @return  string        Content of the page.
+	 * @return string Content of the page.
+	 *
+	 * @since 0.1
+	 * @since 2.0
 	 */
 	public static function set_cache( $data ) {
 		/* Empty? */
@@ -1481,13 +1465,13 @@ final class Cachify {
 		/**
 		 * Filters whether the buffered data should actually be cached
 		 *
-		 * @since 2.3
-		 *
 		 * @param bool   $should_cache  Whether the data should be cached.
 		 * @param string $data          The actual data.
 		 * @param object $method        Instance of the selected caching method.
 		 * @param string $cache_hash    The cache hash.
 		 * @param int    $cache_expires Cache validity period.
+		 *
+		 * @since 2.3.0
 		 */
 		$should_cache = apply_filters(
 			'cachify_store_item',
@@ -1503,12 +1487,12 @@ final class Cachify {
 			/**
 			 * Filters the buffered data itself
 			 *
-			 * @since 2.4
-			 *
 			 * @param string $data          The actual data.
 			 * @param object $method        Instance of the selected caching method.
 			 * @param string $cache_hash    The cache hash.
 			 * @param int    $cache_expires Cache validity period.
+			 *
+			 * @since 2.4.0
 			 */
 			$data = apply_filters( 'cachify_modify_output', $data, self::$method, self::_cache_hash(), self::_cache_expires() );
 
@@ -1530,8 +1514,7 @@ final class Cachify {
 	/**
 	 * Manage the cache.
 	 *
-	 * @since   0.1
-	 * @change  2.3
+	 * @since 0.1
 	 */
 	public static function manage_cache() {
 		/* No caching? */
@@ -1568,10 +1551,9 @@ final class Cachify {
 	/**
 	 * Register CSS
 	 *
-	 * @since   1.0
-	 * @change  2.3.0
+	 * @param string $hook Current hook.
 	 *
-	 * @param   string $hook  Current hook.
+	 * @since 1.0
 	 */
 	public static function add_admin_resources( $hook ) {
 		/* Hooks check */
@@ -1616,8 +1598,7 @@ final class Cachify {
 	/**
 	 * Add options page
 	 *
-	 * @since   1.0
-	 * @change  2.2.2
+	 * @since 1.0
 	 */
 	public static function add_page() {
 		add_options_page(
@@ -1635,10 +1616,9 @@ final class Cachify {
 	/**
 	 * Available caching methods
 	 *
-	 * @since  2.0.0
-	 * @change 2.1.3
+	 * @return array Array of actually available methods.
 	 *
-	 * @return array           Array of actually available methods.
+	 * @since 2.0
 	 */
 	private static function _method_select() {
 		/* Defaults */
@@ -1670,10 +1650,9 @@ final class Cachify {
 	/**
 	 * Minify cache dropdown
 	 *
-	 * @since   2.1.3
-	 * @change  2.1.3
+	 * @return array Key => value array
 	 *
-	 * @return  array    Key => value array
+	 * @since 2.1.3
 	 */
 	private static function _minify_select() {
 		return array(
@@ -1686,8 +1665,7 @@ final class Cachify {
 	/**
 	 * Register settings
 	 *
-	 * @since   1.0
-	 * @change  1.0
+	 * @since 1.0
 	 */
 	public static function register_settings() {
 		register_setting(
@@ -1703,11 +1681,12 @@ final class Cachify {
 	/**
 	 * Validate options
 	 *
-	 * @since   1.0.0
-	 * @change  2.1.3
+	 * @param array $data Array of form values.
 	 *
-	 * @param   array $data  Array of form values.
-	 * @return  array        Array of validated values.
+	 * @return array Array of validated values.
+	 *
+	 * @since 1.0
+	 * @since 2.1.3
 	 */
 	public static function validate_options( $data ) {
 		/* Empty data? */
@@ -1745,8 +1724,7 @@ final class Cachify {
 	/**
 	 * Display options page
 	 *
-	 * @since   1.0
-	 * @change  2.3.0
+	 * @since 1.0
 	 */
 	public static function options_page() {
 		$options = self::_get_options();
@@ -1795,11 +1773,11 @@ final class Cachify {
 	/**
 	 * Return an array with all settings tabs applicable in context of current plugin options.
 	 *
-	 * @since   2.3.0
-	 * @change  2.3.0
-	 *
 	 * @param array $options the options.
+	 *
 	 * @return array
+	 *
+	 * @since 2.3.0
 	 */
 	private static function _get_tabs( $options ) {
 		/* Settings tab is always present */


### PR DESCRIPTION
Changes apply to comment blocks only, no code modified.

* consistent use of `int`/`bool` over `integer`/`boolean`
* consistent indentation of `@param` and `@return` blocks
* use `@since` tags instead of `@change`, where applicable
  `@change` is no valid PHPdoc tag and is has often been used without any context information. Use multiple `@since` declarations for external changes (visibility, arguments, renaming, ...) and remove behavior-related `@change` tags.
* remove redundant `@change` tags
  there is no additional information whatsoever in blocks like
```php
  * @since   2.0.7
  * @change  2.0.7
```
* use version number that actually exist (2.0, 2.3.0, ...)
* remote superfluous `true/false`  additions from tags like `@return bool true/false <description>` 