### PR TITLE
fix robots.txt generation (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Requires PHP 5.6 and WordPress 4.7 or above
 * Enhance: adjust styling for setup instructions (#215, props timse201)
 * Enhance: update hooks for Multisite initialization in WordPress 5.1 and above (#246, props ouun)
 * Enhance: rework flush hooks and add some third-party triggers for Autoptimize and WooCommerce (#225, props timse201)
-
+* Fix: correctly add user-agent to robots.txt (#282) (#283)
 
 ## 2.3.2
 * Fix: enforce WordPress environment for caching modules (#221, props timse201)

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -446,7 +446,7 @@ final class Cachify {
 	public static function robots_txt() {
 		/* HDD only */
 		if ( self::METHOD_HDD === self::$options['use_apc'] ) {
-			echo 'Disallow: */cache/cachify/';
+			echo "User-agent: *\nDisallow: */cache/cachify/\n";
 		}
 	}
 

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -171,7 +171,7 @@ final class Cachify {
 		} else {
 			/* Frontend */
 			add_action( 'template_redirect', array( __CLASS__, 'manage_cache' ), 0 );
-			add_action( 'do_robots', array( __CLASS__, 'robots_txt' ) );
+			add_filter( 'robots_txt', array( __CLASS__, 'robots_txt' ) );
 		}
 	}
 
@@ -439,15 +439,18 @@ final class Cachify {
 	/**
 	 * Modify robots.txt
 	 *
+	 * @param string $output The robots.txt output.
+	 *
 	 * @since 1.0
 	 * @since 2.1.9
-	 * @since 2.4.0 Removed $data parameter and return value.
 	 */
-	public static function robots_txt() {
+	public static function robots_txt( $output ) {
 		/* HDD only */
 		if ( self::METHOD_HDD === self::$options['use_apc'] ) {
-			echo "User-agent: *\nDisallow: */cache/cachify/\n";
+			$output .= "\nUser-agent: *\nDisallow: */cache/cachify/\n";
 		}
+
+		return $output;
 	}
 
 	/**

--- a/tests/test-cachify.php
+++ b/tests/test-cachify.php
@@ -104,4 +104,33 @@ class Test_Cachify extends WP_UnitTestCase {
 		Cachify::on_activation();
 		self::assertEquals( array() , get_option( 'cachify' ), 'Cachify option not initialized' );
 	}
+
+
+	/**
+	 * Test hook for robots.txt customization.
+	 */
+	public function test_robots_txt() {
+		// Initial robots.txt content.
+		$robots_txt = "User-agent: *\nDisallow: /wordpress/wp-admin/\nAllow: /wordpress/wp-admin/admin-ajax.php\n";
+
+		// DB cache enabled.
+		update_option( 'cachify' , array( 'use_apc' => Cachify::METHOD_DB ) );
+		new Cachify();
+
+		self::assertEquals(
+			$robots_txt,
+			Cachify::robots_txt( $robots_txt ),
+			'robots.tst should not be modified using DB cache'
+		);
+
+		// HDD cache enabled.
+		update_option( 'cachify' , array( 'use_apc' => Cachify::METHOD_HDD ) );
+		new Cachify();
+
+		self::assertEquals(
+			$robots_txt . "\nUser-agent: *\nDisallow: */cache/cachify/\n",
+			Cachify::robots_txt( $robots_txt ),
+			'robots.tst should have been modified using HDD cache'
+		);
+	}
 }


### PR DESCRIPTION
This resolves #282.

We now append a complete block including `user-agent` to the _robots.txt_, so that we always generate valid results, independent of the previously added content:
```
User-agent: *
Disallow: */cache/cachify/
```

Without any other plugin, this results in:
```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php

Sitemap: http://example.com/wp-sitemap.xml

User-agent: *
Disallow: */cache/cachify/
```

We also add line breaks before and after this block, because we should not rely on the existence of such be previous/following logic out of our control.

*Additional change:*
In #190 we apparently switched from a "robots_txt" action (which is not a valid action) to the [`do_robots`](https://developer.wordpress.org/reference/hooks/do_robots/) action. 
Actually the first is a filter and I think we should prefer the filter logic, so we switch (back) to [`robots_txt`](https://developer.wordpress.org/reference/hooks/robots_txt/). Also added a test case for this.