### PR TITLE
Adds action triggers to cache flush methods - Allows Cachify flushing to be extended

### DIFF
--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1170,16 +1170,16 @@ final class Cachify {
 		}
 
 		$hash = self::_cache_hash( $url );
-		call_user_func(
-			array(
-				self::$method,
-				'delete_item',
-			),
-			$hash,
-			$url
-		);
+		call_user_func( array( self::$method, 'delete_item' ), $hash, $url );
 
-		/* Call hook for further actions */
+		/**
+		 * Call hook for further actions after cache has been flushed for a single page.
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param string $url  Page URL.
+		 * @param string $hash Cache hash for given URL.
+		 */
 		do_action( 'cachify_removed_cache_by_url', $url, $hash );
 	}
 
@@ -1507,16 +1507,11 @@ final class Cachify {
 			/* MEMCACHED */
 			Cachify_MEMCACHED::clear_cache();
 		} else {
-			call_user_func(
-				array(
-					self::$method,
-					'clear_cache',
-				)
-			);
+			call_user_func( array( self::$method, 'clear_cache' ) );
 		}
 
 		/**
-		 * Call hook for further actions
+		 * Call hook for further actions after total cache has been flushed.
 		 *
 		 * @since 2.4.0
 		 *

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1113,7 +1113,7 @@ final class Cachify {
 			return;
 		}
 
-		$hash = self::_cache_hash( $url )
+		$hash = self::_cache_hash( $url );
 		call_user_func(
 			array(
 				self::$method,

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1113,14 +1113,18 @@ final class Cachify {
 			return;
 		}
 
+		$hash = self::_cache_hash( $url )
 		call_user_func(
 			array(
 				self::$method,
 				'delete_item',
 			),
-			self::_cache_hash( $url ),
+			$hash,
 			$url
 		);
+
+		/* Call hook for further actions */
+		do_action( 'cachify_removed_cache_by_url', $url, $hash );
 	}
 
 	/**
@@ -1451,6 +1455,9 @@ final class Cachify {
 				)
 			);
 		}
+
+		/* Call hook for further actions */
+		do_action( 'cachify_flushed_total_cache', $clear_all_methods );
 
 		/* Transient */
 		delete_transient( 'cachify_cache_size' );

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1515,7 +1515,13 @@ final class Cachify {
 			);
 		}
 
-		/* Call hook for further actions */
+		/**
+		 * Call hook for further actions
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param bool $clear_all_methods All available caching backends have been flushed.
+		 */
 		do_action( 'cachify_flushed_total_cache', $clear_all_methods );
 
 		/* Transient */

--- a/tests/test-cachify.php
+++ b/tests/test-cachify.php
@@ -160,4 +160,55 @@ class Test_Cachify extends WP_UnitTestCase {
 			'robots.txt should have been modified using HDD cache'
 		);
 	}
+
+	/**
+	 * Test call of hooks after flushing the cache.
+	 */
+	public function test_flushed_total_hook() {
+		$flushed_total = array();
+		add_action(
+			'cachify_flushed_total_cache',
+			function( $arg ) use ( &$flushed_total ) {
+				$flushed_total[] = $arg;
+			}
+		);
+
+		Cachify::flush_total_cache( );
+		Cachify::flush_total_cache( false );
+		Cachify::flush_total_cache( true );
+
+		self::assertEquals(
+			array( false, false, true ),
+			$flushed_total,
+			'unexpected hook calls after flushing the cache'
+		);
+	}
+
+	/**
+	 * Test call of hooks after remove cache by URL.
+	 */
+	public function test_removed_by_url_hook() {
+		$flushed_single = array();
+		add_action(
+			'cachify_removed_cache_by_url',
+			function( $url, $hash ) use ( &$flushed_single ) {
+				$flushed_single[] = array( $url, $hash );
+			},
+			10,
+			2
+		);
+
+		Cachify::remove_page_cache_by_url( 'https://example.com/foo' );
+		Cachify::remove_page_cache_by_url( 'https://example.com/bar' );
+
+		self::assertEquals(
+			array(
+				array( 'https://example.com/foo', '45cc6f45ed67ff733a550ceb93ac2694.cachify' ),
+				array( 'https://example.com/bar', '7b579c8fd2d8d8685f9680e7f5fedadc.cachify' ),
+			),
+			$flushed_single,
+			'unexpected hook calls after removing by url'
+		);
+
+	}
 }


### PR DESCRIPTION
I tried to extend Cachify with hooks to handle additional API requests to an edge cache. However, I ended up with some very hacky solutions as there are no action hooks available at the end of the cache flush/delete logics.

This PR simply adds two action triggers to the two main cache flush methods, which I hope I have identified correctly. It allows for any other callback functions to be added after the entire cache or a single cache item has been deleted.

**I really hope** you agree with this and that **it can be merged with the 2.4.0 release**. Redis support and these hooks will make Cachify even more flexible and powerful. Thanks for your great work!