### PR TITLE
[I18n] Fix brand names and Caching method label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,8 @@ Requires PHP 5.6 and WordPress 4.7 or above
 * Fix for the PHP notice "Call to undefined function is_plugin_active_for_network" on WordPress Multisite
 
 ## 2.2.0
-* Toolbar: Display of the "Flush the cachify cache" button on the frontend
-* Toolbar: Controlling the display of the "Flush the cachify cache" button via hook
+* Toolbar: Display of the "Flush the Cachify cache" button on the frontend
+* Toolbar: Controlling the display of the "Flush the Cachify cache" button via hook
 
 ## 2.1.9
 * Vervollständigung des Cachify-Pfades in `robots.txt`: `Disallow: /wp-content/cache/cachify/`

--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -41,7 +41,7 @@ defined( 'ABSPATH' ) || exit;
 					printf(
 						/* translators: Placeholder is the trash icon itself as dashicon */
 						esc_html__( 'Flush the cache by clicking the button below or the %1$s icon in the admin bar.', 'cachify' ),
-						'<span class="dashicons dashicons-trash" aria-hidden="true"></span><span class="screen-reader-text">"' . esc_html__( 'Flush the cachify cache', 'cachify' ) . '"</span>'
+						'<span class="dashicons dashicons-trash" aria-hidden="true"></span><span class="screen-reader-text">"' . esc_html__( 'Flush the Cachify cache', 'cachify' ) . '"</span>'
 					);
 					?>
 				</p>

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -568,7 +568,7 @@ final class Cachify {
 
 		/* Right now item */
 		$items[] = sprintf(
-			'<a href="%s" title="%s: %s" class="cachify-glance">
+			'<a href="%s" title="%s" class="cachify-glance">
             <svg class="cachify-icon cachify-icon--%s" aria-hidden="true" role="img">
                 <use href="%s#cachify-icon-%s" xlink:href="%s#cachify-icon-%s" />
             </svg> %s</a>',
@@ -578,8 +578,12 @@ final class Cachify {
 				),
 				admin_url( 'options-general.php' )
 			),
-			esc_attr( strtolower( $method ) ),
-			esc_html__( 'Caching method', 'cachify' ),
+			sprintf(
+				/* translators: 1: "Caching method label"; 2: Actual method. */
+				esc_html__( '%1$s: %2$s', 'cachify' ),
+				esc_html__( 'Caching method', 'cachify' ),
+				esc_attr( strtolower( $method ) ),
+			),
 			esc_attr( $method ),
 			plugins_url( 'images/symbols.svg', CACHIFY_FILE ),
 			esc_attr( strtolower( $method ) ),

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -662,7 +662,7 @@ final class Cachify {
 											) .
 										'</span>',
 				'meta'   => array(
-					'title' => esc_html__( 'Flush the cachify cache', 'cachify' ),
+					'title' => esc_html__( 'Flush the Cachify cache', 'cachify' ),
 				),
 			)
 		);

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -582,7 +582,7 @@ final class Cachify {
 				/* translators: 1: "Caching method label"; 2: Actual method. */
 				esc_html__( '%1$s: %2$s', 'cachify' ),
 				esc_html__( 'Caching method', 'cachify' ),
-				esc_attr( strtolower( $method ) ),
+				esc_attr( strtolower( $method ) )
 			),
 			esc_attr( $method ),
 			plugins_url( 'images/symbols.svg', CACHIFY_FILE ),

--- a/inc/setup/cachify.hdd.htaccess.php
+++ b/inc/setup/cachify.hdd.htaccess.php
@@ -78,7 +78,7 @@ $ending = '/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:C
 		<?php esc_html_e( 'Within .htaccess, the extension has a higher priority and must be placed above the WordPress Rewrite rules (marked mostly by # BEGIN WordPress … # END WordPress).', 'cachify' ); ?>
 	</li>
 	<li>
-		<?php esc_html_e( 'Changes to the .htaccess file can not be made if PHP is run as fcgi.', 'cachify' ); ?>
+		<?php esc_html_e( 'Changes to the .htaccess file can not be made if PHP is run as FastCGI.', 'cachify' ); ?>
 	</li>
 	<li>
 		<?php esc_html_e( 'If there are partial errors in the redirects within the blog, the shutdown of the Apache Content Cache can help:', 'cachify' ); ?><br />

--- a/inc/setup/cachify.memcached.nginx.php
+++ b/inc/setup/cachify.memcached.nginx.php
@@ -71,7 +71,7 @@ location @nocache {
 		<?php
 		printf(
 			/* translators: code */
-			esc_html__( 'If you have errors please try to change %1$s to %2$s This forces IPv4 because some servers that allow IPv4 and IPv6 are configured to bind memcached to IPv4 only.', 'cachify' ),
+			esc_html__( 'If you have errors please try to change %1$s to %2$s This forces IPv4 because some servers that allow IPv4 and IPv6 are configured to bind Memcached to IPv4 only.', 'cachify' ),
 			'<code>memcached_pass localhost:11211;</code>',
 			'<code>memcached_pass 127.0.0.1:11211;</code>'
 		);

--- a/inc/setup/cachify.memcached.nginx.php
+++ b/inc/setup/cachify.memcached.nginx.php
@@ -71,7 +71,7 @@ location @nocache {
 		<?php
 		printf(
 			/* translators: code */
-			esc_html__( 'If you have errors please try to change %1$s to %2$s This forces IPv4 because some servers that allow IPv4 and IPv6 are configured to bind Memcached to IPv4 only.', 'cachify' ),
+			esc_html__( 'If you have errors please try to change %1$s to %2$s This forces IPv4 because some servers that allow IPv4 and IPv6 are configured to bind memcached to IPv4 only.', 'cachify' ),
 			'<code>memcached_pass localhost:11211;</code>',
 			'<code>memcached_pass 127.0.0.1:11211;</code>'
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -154,8 +154,8 @@ A complete documentation is available in the [online handbook](https://cachify.p
 * Fix for the PHP notice "Call to undefined function is_plugin_active_for_network" on WordPress Multisite
 
 ### 2.2.0 ###
-* Toolbar: Display of the "Flush the cachify cache" button on the frontend
-* Toolbar: Controlling the display of the "Flush the cachify cache" button via hook
+* Toolbar: Display of the "Flush the Cachify cache" button on the frontend
+* Toolbar: Controlling the display of the "Flush the Cachify cache" button via hook
 
 For the complete changelog, check out our [GitHub repository](https://github.com/pluginkollektiv/cachify).
 


### PR DESCRIPTION
Description of these fixes:
- [x] Correct naming for ~memached~ Memcached, ~fcgi~ FastCGI, ~cachify~ Cachify
- [x] Fix `db: Caching method` to `Caching method: db` format, allowing each language to deal with the `%s: %s` (eg. french `%s : %s`)