### PR TITLE
Common interface for the Cachify storage classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 composer.lock
 package-lock.json
 phpunit.*.xml
+tests/coverage/

--- a/cachify.php
+++ b/cachify.php
@@ -91,7 +91,7 @@ spl_autoload_register( 'cachify_autoload' );
  * @param string $class_name the class name.
  */
 function cachify_autoload( $class_name ) {
-	if ( in_array( $class_name, array( 'Cachify', 'Cachify_APC', 'Cachify_DB', 'Cachify_HDD', 'Cachify_MEMCACHED', 'Cachify_REDIS', 'Cachify_CLI' ), true ) ) {
+	if ( in_array( $class_name, array( 'Cachify', 'Cachify_APC', 'Cachify_Backend', 'Cachify_CLI', 'Cachify_DB', 'Cachify_HDD', 'Cachify_MEMCACHED', 'Cachify_REDIS' ), true ) ) {
 		require_once sprintf(
 			'%s/inc/class-%s.php',
 			CACHIFY_DIR,

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,9 @@
     ],
     "test": [
       "phpunit"
+    ],
+    "coverage": [
+      "php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-html tests/coverage"
     ]
   },
   "config": {

--- a/inc/class-cachify-apc.php
+++ b/inc/class-cachify-apc.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Cachify_APC
  */
-final class Cachify_APC {
+final class Cachify_APC implements Cachify_Backend {
 
 	/**
 	 * Availability check
@@ -102,9 +102,12 @@ final class Cachify_APC {
 	/**
 	 * Print the cache
 	 *
+	 * @param bool   $sig_detail  Show details in signature.
+	 * @param string $cache       Cached content.
+	 *
 	 * @since 2.0
 	 */
-	public static function print_cache() {
+	public static function print_cache( $sig_detail, $cache ) {
 		// Not supported.
 	}
 

--- a/inc/class-cachify-backend.php
+++ b/inc/class-cachify-backend.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Interface for caching storage classes.
+ *
+ * @package Cachify
+ */
+
+/* Quit */
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface Cachify Backend
+ */
+interface Cachify_Backend {
+
+	/**
+	 * Availability check
+	 *
+	 * @return bool TRUE if
+	 * available
+	 */
+	public static function is_available();
+
+	/**
+	 * Caching method as string
+	 *
+	 * @return  string Caching method
+	 */
+	public static function stringify_method();
+
+	/**
+	 * Store item in cache
+	 *
+	 * @param string $hash       Hash of the entry.
+	 * @param string $data       Content of the entry.
+	 * @param int    $lifetime   Lifetime of the entry.
+	 * @param bool   $sig_detail Show details in signature.
+	 */
+	public static function store_item( $hash, $data, $lifetime, $sig_detail );
+
+	/**
+	 * Read item from cache
+	 *
+	 * @param string $hash Hash of the entry.
+	 * @return mixed Content of the entry.
+	 */
+	public static function get_item( $hash );
+
+	/**
+	 * Delete item from cache
+	 *
+	 * @param   string $hash  Hash of the entry.
+	 * @param   string $url   URL of the entry.
+	 */
+	public static function delete_item( $hash, $url );
+
+	/**
+	 * Clear the cache
+	 */
+	public static function clear_cache();
+
+	/**
+	 * Print the cache
+	 *
+	 * @param bool   $sig_detail  Show details in signature.
+	 * @param string $cache       Cached content.
+	 */
+	public static function print_cache( $sig_detail, $cache );
+}

--- a/inc/class-cachify-db.php
+++ b/inc/class-cachify-db.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Cachify_DB
  */
-final class Cachify_DB {
+final class Cachify_DB implements Cachify_Backend {
 
 	/**
 	 * Availability check
@@ -41,10 +41,11 @@ final class Cachify_DB {
 	 * @param string $hash     Hash of the entry.
 	 * @param string $data     Content of the entry.
 	 * @param int    $lifetime Lifetime of the entry.
+	 * @param bool   $sig_detail Show details in signature.
 	 *
 	 * @since 2.0
 	 */
-	public static function store_item( $hash, $data, $lifetime ) {
+	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
 		/* Do not store empty data. */
 		if ( empty( $data ) ) {
 			trigger_error( __METHOD__ . ': Empty input.', E_USER_WARNING );

--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Cachify_HDD
  */
-final class Cachify_HDD {
+final class Cachify_HDD implements Cachify_Backend {
 
 	/**
 	 * Availability check
@@ -79,11 +79,12 @@ final class Cachify_HDD {
 	/**
 	 * Read item from cache
 	 *
+	 * @param string $hash Hash of the entry.
 	 * @return bool True if cache is present.
 	 *
 	 * @since 2.0
 	 */
-	public static function get_item() {
+	public static function get_item( $hash ) {
 		return is_readable(
 			self::_file_html()
 		);
@@ -118,9 +119,12 @@ final class Cachify_HDD {
 	/**
 	 * Print the cache
 	 *
+	 * @param bool  $sig_detail Show details in signature.
+	 * @param array $cache      Array of cache values.
+	 *
 	 * @since 2.0
 	 */
-	public static function print_cache() {
+	public static function print_cache( $sig_detail, $cache ) {
 		$filename = self::_file_html();
 		$size     = is_readable( $filename ) ? readfile( $filename ) : false;
 

--- a/inc/class-cachify-memcached.php
+++ b/inc/class-cachify-memcached.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Cachify_MEMCACHED
  */
-final class Cachify_MEMCACHED {
+final class Cachify_MEMCACHED implements Cachify_Backend {
 
 	/**
 	 * Memcached-Object
@@ -140,9 +140,12 @@ final class Cachify_MEMCACHED {
 	/**
 	 * Print the cache
 	 *
+	 * @param bool  $sig_detail Show details in signature.
+	 * @param array $cache      Array of cache values.
+	 *
 	 * @since 2.0.7
 	 */
-	public static function print_cache() {
+	public static function print_cache( $sig_detail, $cache ) {
 		// Not supported.
 	}
 

--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 2.4
  */
-final class Cachify_REDIS {
+final class Cachify_REDIS implements Cachify_Backend {
 
 	/**
 	 * Redis-Object

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,12 @@
             <file>cachify.php</file>
             <directory suffix=".php">inc</directory>
         </include>
+        <exclude>
+            <directory suffix=".php">inc/setup/</directory>
+            <file>inc/cachify.settings.php</file>
+            <file>inc/cachify.settings-footer.php</file>
+        </exclude>
+
         <report>
             <clover outputFile="phpunit.coverage.xml"/>
         </report>

--- a/tests/test-cachify-db.php
+++ b/tests/test-cachify-db.php
@@ -34,7 +34,8 @@ class Test_Cachify_DB extends WP_UnitTestCase {
 		Cachify_DB::store_item(
 			'965b4abf2414e45036ab90c9d3f8dbc7',
 			'<html><head><title>Test Me</title></head><body><p>Test Content.</p></body></html>',
-			3600
+			3600,
+			false
 		);
 
 		$cached = Cachify_DB::get_item( '965b4abf2414e45036ab90c9d3f8dbc7' );
@@ -53,7 +54,8 @@ class Test_Cachify_DB extends WP_UnitTestCase {
 		Cachify_DB::store_item(
 			'ef7e4a0540f6cde19e6eb658c69b0064',
 			'<html><head><title>Test 2</title></head><body><p>Test Content #2.</p></body></html>',
-			3600
+			3600,
+			false
 		);
 		self::assertIsArray( Cachify_DB::get_item( 'ef7e4a0540f6cde19e6eb658c69b0064' ), 'second item was not stored' );
 

--- a/tests/test-cachify-hdd.php
+++ b/tests/test-cachify-hdd.php
@@ -52,7 +52,7 @@ class Test_Cachify_HDD extends WP_UnitTestCase {
 	 * Test the actual caching.
 	 */
 	public function test_caching() {
-		self::assertFalse( Cachify_HDD::get_item() );
+		self::assertFalse( Cachify_HDD::get_item( '965b4abf2414e45036ab90c9d3f8dbc7' ) );
 
 		self::go_to( '/testme/' );
 		Cachify_HDD::store_item(
@@ -61,7 +61,7 @@ class Test_Cachify_HDD extends WP_UnitTestCase {
 			3600, // Ignored.
 			false
 		);
-		self::assertTrue( Cachify_HDD::get_item() );
+		self::assertTrue( Cachify_HDD::get_item( '965b4abf2414e45036ab90c9d3f8dbc7' ) );
 		self::assertTrue( is_file( CACHIFY_CACHE_DIR . DIRECTORY_SEPARATOR . 'example.org/testme/index.html' ) );
 		$cached = file_get_contents( CACHIFY_CACHE_DIR . DIRECTORY_SEPARATOR . 'example.org/testme/index.html' );
 		self::assertStringStartsWith(
@@ -81,7 +81,7 @@ Generated @ ',
 			3600, // Ignored.
 			false
 		);
-		self::assertTrue( Cachify_HDD::get_item() );
+		self::assertTrue( Cachify_HDD::get_item( '965b4abf2414e45036ab90c9d3f8dbc7' ) );
 		self::assertTrue( is_file( CACHIFY_CACHE_DIR . DIRECTORY_SEPARATOR . 'example.org/testme/sub/index.html' ) );
 
 		// Another item.
@@ -118,6 +118,6 @@ HDD Cache @ ',
 		Cachify_HDD::clear_cache();
 		self::assertFalse( is_dir( CACHIFY_CACHE_DIR . DIRECTORY_SEPARATOR . 'example.org/testme' ), 'empty directory was not deleted' );
 		self::assertFalse( is_dir( CACHIFY_CACHE_DIR . DIRECTORY_SEPARATOR . 'example.org/test2' ), 'second test page was not deleted' );
-		self::assertFalse( Cachify_HDD::get_item() );
+		self::assertFalse( Cachify_HDD::get_item( '965b4abf2414e45036ab90c9d3f8dbc7' ) );
 	}
 }

--- a/tests/test-cachify-redis.php
+++ b/tests/test-cachify-redis.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Cachify Redis tests.
+ *
+ * @package Cachify
+ */
+
+/**
+ * Class Test_Cachify_REDIS.
+ *
+ * Tests for the Cachify Redis backend.
+ */
+class Test_Cachify_REDIS extends WP_UnitTestCase {
+	/**
+	 * Test backend availability.
+	 */
+	public function test_is_available() {
+		self::assertEquals( class_exists( 'Redis' ), Cachify_REDIS::is_available() );
+	}
+
+	/**
+	 * Test backend availability.
+	 */
+	public function test_stringify_method() {
+		self::assertEquals( 'Redis', Cachify_REDIS::stringify_method() );
+	}
+}


### PR DESCRIPTION
I started to collect the least common methods with their arguments. It is now possible to guarantee a common interface by implementing **Cachify_Backend** in the interested classes.

I also made the overall coverage more visible and narrowed the output down to the classes (and not template-like the setup code for example):

![image](https://github.com/pluginkollektiv/cachify/assets/1012205/12d229c8-4247-4607-91cb-ce2d5cd616d9)

