### PR TITLE
refactor and fix nginx/htaccess config examples

### DIFF
--- a/inc/setup/cachify.apc.htaccess.php
+++ b/inc/setup/cachify.apc.htaccess.php
@@ -8,11 +8,9 @@
 /* Quit */
 defined( 'ABSPATH' ) || exit;
 
-$beginning = '&lt;Files index.php&gt;
-  php_value auto_prepend_file ';
-
-$ending = '/cachify/apc/proxy.php
-&lt;/Files&gt;';
+$htaccess = '<Files index.php>
+  php_value auto_prepend_file ' . WP_PLUGIN_DIR . '/cachify/apc/proxy.php
+</Files>';
 
 // phpcs:disable Squiz.PHP.EmbeddedPhp
 ?>
@@ -21,10 +19,5 @@ $ending = '/cachify/apc/proxy.php
 <p><?php esc_html_e( 'Please add the following lines to your .htaccess file', 'cachify' ); ?></p>
 
 <textarea rows="5" class="large-text code cachify-code" name="code" readonly><?php
-	printf(
-		'%s%s%s',
-		esc_html( $beginning ),
-		esc_html( WP_PLUGIN_DIR ),
-		esc_html( $ending )
-	);
-	?></textarea>
+	echo esc_html( $htaccess );
+?></textarea>

--- a/inc/setup/cachify.apc.nginx.php
+++ b/inc/setup/cachify.apc.nginx.php
@@ -8,17 +8,15 @@
 /* Quit */
 defined( 'ABSPATH' ) || exit;
 
-$beginning = 'location ~ .php {
+$nginx_conf = 'location ~ .php {
   include fastcgi_params;
   fastcgi_pass 127.0.0.1:9000;
-  <strong>fastcgi_param PHP_VALUE auto_prepend_file=';
-
-$ending = '/cachify/apc/proxy.php</strong>;
+  fastcgi_param PHP_VALUE auto_prepend_file=' . WP_PLUGIN_DIR . '/cachify/apc/proxy.php;
 
   location ~ /wp-admin/ {
     include fastcgi_params;
     fastcgi_pass 127.0.0.1:9000;
-    <strong>fastcgi_param PHP_VALUE auto_prepend_file=</strong>;
+    fastcgi_param PHP_VALUE auto_prepend_file=;
   }
 }';
 
@@ -29,12 +27,7 @@ $ending = '/cachify/apc/proxy.php</strong>;
 <p><?php esc_html_e( 'Please add the following lines to your nginx PHP configuration', 'cachify' ); ?></p>
 
 <textarea rows="13" class="large-text code cachify-code" name="code" readonly><?php
-	printf(
-		'%s%s%s',
-		esc_html( $beginning ),
-		esc_html( WP_PLUGIN_DIR ),
-		esc_html( $ending )
-	);
-	?></textarea>
+	echo esc_html( $nginx_conf );
+?></textarea>
 
 <small>(<?php esc_html_e( 'You might need to adjust the non-highlighted lines to your needs.', 'cachify' ); ?>)</small>

--- a/inc/setup/cachify.hdd.nginx.php
+++ b/inc/setup/cachify.hdd.nginx.php
@@ -13,9 +13,11 @@ defined( 'ABSPATH' ) || exit;
 <p><?php esc_html_e( 'Please add the following lines to your nginx.conf', 'cachify' ); ?></p>
 
 <textarea rows="16" class="large-text code cachify-code" name="code" readonly>
+<?php if ( Cachify_HDD::is_gzip_enabled() ) : ?>
 ## GZIP
 gzip_static on;
 
+<?php endif; ?>
 ## CHARSET
 charset utf-8;
 

--- a/inc/setup/cachify.memcached.nginx.php
+++ b/inc/setup/cachify.memcached.nginx.php
@@ -13,9 +13,6 @@ defined( 'ABSPATH' ) || exit;
 <p><?php esc_html_e( 'Please add the following lines to your nginx.conf', 'cachify' ); ?></p>
 
 <textarea rows="16" class="large-text code cachify-code" name="code" readonly>
-## GZIP
-gzip_static on;
-
 ## CHARSET
 charset utf-8;
 


### PR DESCRIPTION
**hdd.htaccess** (see #248):
* simplify the code to generate our .htaccess config example
* fix rewrite condition for empty query string
* remove some redundant HTML escapes

Example output with GZIP enabled 
```
# BEGIN CACHIFY
<IfModule mod_rewrite.c>
  RewriteEngine on

  # set hostname directory
  RewriteCond %{HTTPS} on
  RewriteRule .* - [E=CACHIFY_HOST:https-%{HTTP_HOST}]
  RewriteCond %{HTTPS} off
  RewriteRule .* - [E=CACHIFY_HOST:%{HTTP_HOST}]

  # set subdirectory
  RewriteCond %{REQUEST_URI} /$
  RewriteRule .* - [E=CACHIFY_DIR:%{REQUEST_URI}]
  RewriteCond %{REQUEST_URI} ^$
  RewriteRule .* - [E=CACHIFY_DIR:/]

  # gzip
  RewriteRule .* - [E=CACHIFY_SUFFIX:]
  <IfModule mod_mime.c>
    RewriteCond %{HTTP:Accept-Encoding} gzip
    RewriteRule .* - [E=CACHIFY_SUFFIX:.gz]
    AddType text/html .gz
    AddEncoding gzip .gz
  </IfModule>

  # Main Rules
  RewriteCond %{HTTP_ACCEPT} .*text/html.*
  RewriteCond %{REQUEST_METHOD} GET
  RewriteCond %{QUERY_STRING} ^$
  RewriteCond %{REQUEST_URI} !^/(wp-admin|wp-content/cache)/.*
  RewriteCond %{HTTP_COOKIE} !(wp-postpass|wordpress_logged_in|comment_author)_
  RewriteCond /var/www/html/wordpress/wp-content/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:CACHIFY_SUFFIX} -f
  RewriteRule ^(.*) /wordpress/wp-content/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:CACHIFY_SUFFIX} [L]
</IfModule>
# END CACHIFY
```

**hdd.nginx**
* only add `gzip_static on;` directive to nginx HDD example, if _gzip_ is enabled

**apc.htaccess**
* simplify the code to generate our .htaccess config example

**apc.nginx**
* simplify the code to generate our .htaccess config example
* remove ` <strong>` tags which are now allowed within `<textarea>` (regression from #215)