### PR TITLE
prepare release of v2.4.0 (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,41 @@
 # Changelog
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## unreleased
+## 2.4.0
 
 Requires PHP 5.6 and WordPress 4.7 or above
 
-* Fix: invalidate cache when permalink changes (#285, #286, props raffaelj)
+* New: introduce Redis (also KeyDB and Valkey) support using the _phpredis_ module (#253), (#252, props @newtovaux)
+* New: add `cachify_modify_output` filter
+* New: add `cachify_create_gzip_files` to disable creation of static GZip files (#262, props @angcl)
+* New: add hooks `cachify_removed_cache_by_url` and `cachify_flushed_total_cache` for additional actions after clearing (#294, props @ouun)
+* Removed: APC support (#304)
+* Enhance: adjust styling for setup instructions (#215, props @timse201)
+* Enhance: update hooks for Multisite initialization in WordPress 5.1 and above (#246, props @ouun)
+* Enhance: rework flush hooks and add some third-party triggers for Autoptimize and WooCommerce (#225, props @timse201)
+* Enhance: clean up some internal error suppressions (#256)
+* Enhance: inform user on cache clear in admin bar (#257, props @angcl)
+* Enhance: do not flush the cache for post revisions (#261, props @angcl)
+* Enhance: prevent unnecessary cache clearing in some cases (#223) (#224, props @timse201)
+* Enhance: remove empty directories when clearing the HDD cache (#289)
+* Enhance: introduce common interface for caching backends (#298, props @lloc)
+* Enhance: enhance examples for .htaccess and nginx configuration (#302)
+* Enhance: show admin notice instead of silent fallback to DB cache, if selected backend is unavailable (#305)
+* Enhance: disable gzip creation of required PHP extension is missing (#308)
+* Enhance: various internal code clean ups
+* Fix: invalidate cache when permalink changes (#285, #286, props @raffaelj)
 * Fix: remove empty directories when pruning the HDD cache (#289)
-* Enhance: adjust styling for setup instructions (#215, props timse201)
-* Enhance: update hooks for Multisite initialization in WordPress 5.1 and above (#246, props ouun)
-* Enhance: rework flush hooks and add some third-party triggers for Autoptimize and WooCommerce (#225, props timse201)
 * Fix: correctly add user-agent to robots.txt (#282) (#283)
+* Fix: exclude _sitemap.xml_ from caching (#242) (#254)
+* Fix: prevent cache generation of non-GET requests (#200) (#258)
+* Fix: prevent cache generation of requests with status different from 200 OK (#266) (#267, props @karlkowald)
+* Fix: prevent cache generation of non-HTML responses when using content negotiation (#265) (#273, props @Ancocodet)
+* Fix: fix styling for various dark mode plugins (#264) (#278)
+* Fix: fix SVG markup for icons in dashboard widget (#269, props @Latz)
+* Fix: added missing .gz suffix in htaccess (#287) (#291, props @raffaelj)
+* Fix: fix some brand names and unify spelling (#297, props @pedro-mendonca)
+* Maintenance: Tested up to WordPress 6.6
+
 
 ## 2.3.2
 * Fix: enforce WordPress environment for caching modules (#221, props timse201)

--- a/cachify.php
+++ b/cachify.php
@@ -7,7 +7,7 @@
  * Plugin URI:  https://cachify.pluginkollektiv.org
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.3.2
+ * Version:     2.4.0
  * Text Domain: cachify
  *
  * @package Cachify

--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Cachify_REDIS class
  *
- * @since 2.4
+ * @since 2.4.0
  */
 final class Cachify_REDIS implements Cachify_Backend {
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              cache, caching, performance, optimize, speed
 * Requires at least: 4.7
-* Tested up to:      5.9
+* Tested up to:      6.6
 * Requires PHP:      5.6
-* Stable tag:        2.3.2
+* Stable tag:        2.4.0
 * License:           GPLv2 or later
 * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -99,6 +99,41 @@ Allow: /`
 A complete documentation is available in the [online handbook](https://cachify.pluginkollektiv.org/documentation/).
 
 ## Changelog ##
+
+### 2.4.0 ###
+
+Requires PHP 5.6 and WordPress 4.7 or above
+
+* New: introduce Redis (also KeyDB and Valkey) support using the _phpredis_ module (#253), (#252, props @newtovaux)
+* New: add `cachify_modify_output` filter
+* New: add `cachify_create_gzip_files` to disable creation of static GZip files (#262, props @angcl)
+* New: add hooks `cachify_removed_cache_by_url` and `cachify_flushed_total_cache` for additional actions after clearing (#294, props @ouun)
+* Removed: APC support (#304)
+* Enhance: adjust styling for setup instructions (#215, props @timse201)
+* Enhance: update hooks for Multisite initialization in WordPress 5.1 and above (#246, props @ouun)
+* Enhance: rework flush hooks and add some third-party triggers for Autoptimize and WooCommerce (#225, props @timse201)
+* Enhance: clean up some internal error suppressions (#256)
+* Enhance: inform user on cache clear in admin bar (#257, props @angcl)
+* Enhance: do not flush the cache for post revisions (#261, props @angcl)
+* Enhance: prevent unnecessary cache clearing in some cases (#223) (#224, props @timse201)
+* Enhance: remove empty directories when clearing the HDD cache (#289)
+* Enhance: introduce common interface for caching backends (#298, props @lloc)
+* Enhance: enhance examples for .htaccess and nginx configuration (#302)
+* Enhance: show admin notice instead of silent fallback to DB cache, if selected backend is unavailable (#305)
+* Enhance: disable gzip creation of required PHP extension is missing (#308)
+* Enhance: various internal code clean ups
+* Fix: invalidate cache when permalink changes (#285, #286, props @raffaelj)
+* Fix: remove empty directories when pruning the HDD cache (#289)
+* Fix: correctly add user-agent to robots.txt (#282) (#283)
+* Fix: exclude _sitemap.xml_ from caching (#242) (#254)
+* Fix: prevent cache generation of non-GET requests (#200) (#258)
+* Fix: prevent cache generation of requests with status different from 200 OK (#266) (#267, props @karlkowald)
+* Fix: prevent cache generation of non-HTML responses when using content negotiation (#265) (#273, props @Ancocodet)
+* Fix: fix styling for various dark mode plugins (#264) (#278)
+* Fix: fix SVG markup for icons in dashboard widget (#269, props @Latz)
+* Fix: added missing .gz suffix in htaccess (#287) (#291, props @raffaelj)
+* Fix: fix some brand names and unify spelling (#297, props @pedro-mendonca)
+* Maintenance: Tested up to WordPress 6.6
 
 ### 2.3.2 ###
 * Fix: enforce WordPress environment for caching modules (#221, props timse201)


### PR DESCRIPTION
* add changelog entries
* raise version number to 2.4.0
* raise "Tested up to:" to 6.6
* unify "since" comments

If you want to test the new plugin, you may use this package and install at own risk:

* ~[Release 2.4.0-beta.1](https://github.com/pluginkollektiv/cachify/releases/tag/2.4.0-beta.1) ([cachify.2.4.0-beta1.zip](https://github.com/pluginkollektiv/cachify/releases/download/2.4.0-beta.1/cachify.2.4.0-beta1.zip))~
* [Release 2.4.0-beta.2](https://github.com/pluginkollektiv/cachify/releases/tag/2.4.0-beta.2) ([cachify.2.4.0-beta2.zip](https://github.com/pluginkollektiv/cachify/releases/download/2.4.0-beta.2/cachify.2.4.0.beta2.zip))

