### PR TITLE
fix: test if gzip extension is available

### DIFF
--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -33,6 +33,11 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.4.0
 	 */
 	public static function is_gzip_enabled() {
+		if ( ! function_exists( 'gzencode' ) ) {
+			// GZip is not available on the system.
+			return false;
+		}
+
 		/**
 		 * Filter that allows to enable/disable gzip file creation
 		 *

--- a/tests/test-cachify-hdd.php
+++ b/tests/test-cachify-hdd.php
@@ -33,7 +33,16 @@ class Test_Cachify_HDD extends WP_UnitTestCase {
 	 * Test GZip availability.
 	 */
 	public function test_is_gzip_enabled() {
-		self::assertTrue( Cachify_HDD::is_gzip_enabled(), 'GZip should be enabled by default' );
+		if ( ! function_exists( 'gzencode' ) ) {
+			self::assertFalse( Cachify_HDD::is_gzip_enabled(), 'GZip should be disabled, if not available' );
+
+			// Define gzencode function for testing the hook.
+			function gzencode( $data, $level = -1 ) {
+				return $data;
+			}
+		}
+
+		self::assertTrue( Cachify_HDD::is_gzip_enabled(), 'GZip should be enabled if available' );
 
 		$capture = null;
 		add_filter(


### PR DESCRIPTION
If _zlib_ PHP extension is not loaded and there is no substitute in place, `gzencode()` does not exist and generation of compressed files will fail.

Add a simple `function_exists()` test to prevent this.