### PR TITLE
ci: install SVN, if not available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install SVN
+        run: |
+          if ! command -v svn > /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y subversion
+          fi
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -22,6 +22,17 @@ download() {
         curl -s "$1" > "$2";
     elif [ `which wget` ]; then
         wget -nv -O "$2" "$1"
+    else
+        echo "Error: Neither curl nor wget is installed."
+        exit 1
+    fi
+}
+
+# Check if svn is installed
+check_svn_installed() {
+    if ! command -v svn > /dev/null; then
+        echo "Error: svn is not installed. Please install svn and try again."
+        exit 1
     fi
 }
 
@@ -64,6 +75,7 @@ install_wp() {
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 		mkdir -p $TMPDIR/wordpress-trunk
 		rm -rf $TMPDIR/wordpress-trunk/*
+        check_svn_installed
 		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
 		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
 	else
@@ -108,6 +120,7 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		rm -rf $WP_TESTS_DIR/{includes,data}
+        check_svn_installed
 		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi


### PR DESCRIPTION
Default Ubuntu 24.04 runner images no longer have subverison installed. Both deployment actions handle installation in their latest versions, but we require it in our test workflow, too. Add a setup step to install it, if the "svn" command does not exist.