### PR TITLE
fix validation of redis context parameters array (#315)

### DIFF
--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -271,7 +271,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 			if ( count( $con ) > 5 ) {
 				$con[5] = floatval( $con[5] );  // Read timeout in seconds.
 			}
-			if ( count( $con ) > 6 && ! is_null( $con[6] ) && is_array( $con[6] ) ) {
+			if ( count( $con ) > 6 && ! is_null( $con[6] ) && ! is_array( $con[6] ) ) {
 				return false;  // Context parameters, e.g. authentication (since PhpRedis 5.3).
 			}
 			if ( count( $con ) > 7 ) {


### PR DESCRIPTION
The optional 7th argument the Redis::connect() holds an array of context parameters, required for authentication. This parameter can either be NULL or an array.

Fix the condition, so it does not reject arrays.

resolves #315