### PR TITLE
Introduce PHPStan and adjust minimum requirements  

### DIFF
--- a/.github/workflows/phpstan-ci.yml
+++ b/.github/workflows/phpstan-ci.yml
@@ -1,0 +1,21 @@
+name: Run PHPStan
+
+on: [push, pull_request]
+
+jobs:
+  run-phpstan:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer, cs2pr
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --no-scripts
+      - name: PHPStan
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,11 @@
     "squizlabs/php_codesniffer": "^3.11",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "wp-coding-standards/wpcs": "^3.2",
-    "yoast/phpunit-polyfills": "^4.0"
+    "yoast/phpunit-polyfills": "^4.0",
+    "phpstan/extension-installer": "^1.4",
+    "phpstan/phpstan": "^1.12",
+    "szepeviktor/phpstan-wordpress": "^v1.3",
+    "php-stubs/wp-cli-stubs": "^v2.12"
   },
   "scripts": {
     "post-install-cmd": [
@@ -71,12 +75,16 @@
     ],
     "coverage": [
       "php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-html tests/coverage"
+    ],
+    "phpstan": [
+        "phpstan analyse --memory-limit=1G"
     ]
   },
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
-      "composer/installers": true
+      "composer/installers": true,
+      "phpstan/extension-installer": true
     }
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,15 @@
+parameters:
+    level: 1
+    paths:
+        - inc/
+        - cachify.php
+    scanFiles:
+        - %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-stubs.php
+        - %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
+        #- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
+        #- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-tools-stubs.php
+    excludePaths:
+        - inc/cachify.settings.php
+    ignoreErrors:
+        - '/^Constant CACHIFY_BASE not found\.$/'
+        - '/^Constant DOMAIN_CURRENT_SITE not found\.$/'


### PR DESCRIPTION
This PR introduces **PHPStan** with the initial level set to **1**, with the goal of gradually increasing it to at least **5** or higher over time.  

### Changes and Improvements  

- **PHPStan Integration**  
  - PHPStan can be executed locally using `composer phpstan`.  
  - It has also been added as an additional **GitHub workflow** for automated checks.  

- **Minimum PHP and WordPress Requirements**  
  - PHPStan requires at least **PHP 7.2**, so this PR suggests:  
    - Dropping support for **PHP 5.6**.  
    - Setting the minimum requirements to **WordPress 5.1** and **PHP 7.2**.  
  - As a sidenote, WordPress 5.1 includes a fix for a bug in the test suite introduced after version 4.x.  

- **PHP 8.4 Compatibility**  
  - **PHP 8.4** has been added to the test checks. 