### PR TITLE
move select helpers from private methods into settings file

### DIFF
--- a/inc/cachify.settings.php
+++ b/inc/cachify.settings.php
@@ -7,6 +7,32 @@
 
 /* Quit */
 defined( 'ABSPATH' ) || exit;
+
+/*
+ * Collect available caching methods.
+ */
+$method_select = array(
+	Cachify::METHOD_DB  => __( 'Database', 'cachify' ),
+);
+if ( Cachify_HDD::is_available() ) {
+	$method_select[ Cachify::METHOD_HDD ] = __( 'Hard disk', 'cachify' );
+}
+if ( Cachify_MEMCACHED::is_available() ) {
+	$method_select[ Cachify::METHOD_MMC ] = __( 'Memcached', 'cachify' );
+}
+if ( Cachify_REDIS::is_available() ) {
+	$method_select[ Cachify::METHOD_REDIS ] = __( 'Redis', 'cachify' );
+}
+
+/*
+ * Minify cache dropdown
+ */
+$minify_select = array(
+	Cachify::MINIFY_DISABLED  => __( 'No minify', 'cachify' ),
+	Cachify::MINIFY_HTML_ONLY => __( 'HTML', 'cachify' ),
+	Cachify::MINIFY_HTML_JS   => __( 'HTML + Inline JavaScript', 'cachify' ),
+);
+
 ?>
 
 <form method="post" action="options.php">
@@ -18,7 +44,7 @@ defined( 'ABSPATH' ) || exit;
 			</th>
 			<td>
 				<select name="cachify[use_apc]" id="cachify_cache_method">
-					<?php foreach ( self::_method_select() as $k => $v ) { ?>
+					<?php foreach ( $method_select as $k => $v ) { ?>
 						<option value="<?php echo esc_attr( $k ); ?>" <?php selected( $options['use_apc'], $k ); ?>><?php echo esc_html( $v ); ?></option>
 					<?php } ?>
 				</select>
@@ -32,7 +58,7 @@ defined( 'ABSPATH' ) || exit;
 			<td>
 				<input type="number" min="0" step="1" name="cachify[cache_expires]" id="cachify_cache_expires" value="<?php echo esc_attr( $options['cache_expires'] ); ?>" class="small-text" />
 				<?php esc_html_e( 'Hours', 'cachify' ); ?>
-				<?php if ( self::METHOD_HDD === $options['use_apc'] ) : ?>
+				<?php if ( Cachify::METHOD_HDD === $options['use_apc'] ) : ?>
 					<p class="description"><?php esc_html_e( 'HDD cache will only expire correctly when triggered by a system cron.', 'cachify' ); ?></p>
 				<?php endif; ?>
 
@@ -119,7 +145,7 @@ defined( 'ABSPATH' ) || exit;
 			</th>
 			<td>
 				<select name="cachify[compress_html]" id="cachify_compress_html">
-					<?php foreach ( self::_minify_select() as $k => $v ) { ?>
+					<?php foreach ( $minify_select as $k => $v ) { ?>
 					<option value="<?php echo esc_attr( $k ); ?>" <?php selected( $options['compress_html'], $k ); ?>>
 						<?php echo esc_html( $v ); ?>
 					</option>

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1739,55 +1739,6 @@ final class Cachify {
 	}
 
 	/**
-	 * Available caching methods
-	 *
-	 * @return array Array of actually available methods.
-	 *
-	 * @since 2.0
-	 */
-	private static function _method_select() {
-		/* Defaults */
-		$methods = array(
-			self::METHOD_DB  => esc_html__( 'Database', 'cachify' ),
-			self::METHOD_HDD => esc_html__( 'Hard disk', 'cachify' ),
-			self::METHOD_MMC => esc_html__( 'Memcached', 'cachify' ),
-			self::METHOD_REDIS => esc_html__( 'Redis', 'cachify' ),
-		);
-
-		/* Memcached? */
-		if ( ! Cachify_MEMCACHED::is_available() ) {
-			unset( $methods[3] );
-		}
-
-		/* HDD */
-		if ( ! Cachify_HDD::is_available() ) {
-			unset( $methods[2] );
-		}
-
-		/* Redis */
-		if ( ! Cachify_REDIS::is_available() ) {
-			unset( $methods[4] );
-		}
-
-		return $methods;
-	}
-
-	/**
-	 * Minify cache dropdown
-	 *
-	 * @return array Key => value array
-	 *
-	 * @since 2.1.3
-	 */
-	private static function _minify_select() {
-		return array(
-			self::MINIFY_DISABLED  => esc_html__( 'No minify', 'cachify' ),
-			self::MINIFY_HTML_ONLY => esc_html__( 'HTML', 'cachify' ),
-			self::MINIFY_HTML_JS   => esc_html__( 'HTML + Inline JavaScript', 'cachify' ),
-		);
-	}
-
-	/**
 	 * Register settings
 	 *
 	 * @since 1.0


### PR DESCRIPTION
Both helpers are only used exactly once when building the settings view. Move the logic into the settings file itself, initialize arrays directly and remove double HTML escaping.