### PR TITLE
update minimum requirements to PHP 7.2 and WP 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '5.6'
-            wordpress: '4.7'
+          - php: '7.2'
+            wordpress: '5.1'
           - php: '7.4'
             wordpress: '5.9'
           - php: '8.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,10 @@ jobs:
       - name: Setup DB
         uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql-version: 'mysql-5.7'
+          mysql-version: 'mysql-8.0'
           root-password: "root"
+          my-cnf: |
+            default_authentication_plugin=mysql_native_password
       - name: Setup WP
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 "${{ matrix.wordpress }}"
       - name: PHP unit tests

--- a/cachify.php
+++ b/cachify.php
@@ -91,7 +91,7 @@ spl_autoload_register( 'cachify_autoload' );
  *
  * @param string $class_name the class name.
  */
-function cachify_autoload( $class_name ) {
+function cachify_autoload( string $class_name ): void {
 	if ( in_array( $class_name, array( 'Cachify', 'Cachify_Backend', 'Cachify_CLI', 'Cachify_DB', 'Cachify_HDD', 'Cachify_MEMCACHED', 'Cachify_NOOP', 'Cachify_REDIS' ), true ) ) {
 		require_once sprintf(
 			'%s/inc/class-%s.php',

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
     "forum": "https://wordpress.org/support/plugin/cachify"
   },
   "require": {
-    "php": ">=5.6",
-    "composer/installers": "^v1|^v2"
+    "php": ">=7.2",
+    "composer/installers": "^v2"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^v1.0",
     "matthiasmullie/minify": "^1.3",
-    "phpunit/phpunit": "^5|^7|^9",
+    "phpunit/phpunit": "^7|^9",
     "squizlabs/php_codesniffer": "^3.11",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "wp-coding-standards/wpcs": "^3.1",
-    "yoast/phpunit-polyfills": "^2.0"
+    "wp-coding-standards/wpcs": "^3.2",
+    "yoast/phpunit-polyfills": "^4.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/inc/class-cachify-backend.php
+++ b/inc/class-cachify-backend.php
@@ -16,17 +16,16 @@ interface Cachify_Backend {
 	/**
 	 * Availability check
 	 *
-	 * @return bool TRUE if
-	 * available
+	 * @return bool TRUE if available
 	 */
-	public static function is_available();
+	public static function is_available(): bool;
 
 	/**
 	 * Caching method as string
 	 *
-	 * @return  string Caching method
+	 * @return string Caching method
 	 */
-	public static function stringify_method();
+	public static function stringify_method(): string;
 
 	/**
 	 * Store item in cache
@@ -36,7 +35,7 @@ interface Cachify_Backend {
 	 * @param int    $lifetime   Lifetime of the entry.
 	 * @param bool   $sig_detail Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sig_detail );
+	public static function store_item( string $hash, string $data, int $lifetime, bool $sig_detail ): void;
 
 	/**
 	 * Read item from cache
@@ -44,20 +43,20 @@ interface Cachify_Backend {
 	 * @param string $hash Hash of the entry.
 	 * @return mixed Content of the entry.
 	 */
-	public static function get_item( $hash );
+	public static function get_item( string $hash );
 
 	/**
 	 * Delete item from cache
 	 *
-	 * @param   string $hash  Hash of the entry.
-	 * @param   string $url   URL of the entry.
+	 * @param string $hash Hash of the entry.
+	 * @param string $url  URL of the entry.
 	 */
-	public static function delete_item( $hash, $url );
+	public static function delete_item( string $hash, string $url ): void;
 
 	/**
 	 * Clear the cache
 	 */
-	public static function clear_cache();
+	public static function clear_cache(): void;
 
 	/**
 	 * Print the cache
@@ -65,5 +64,5 @@ interface Cachify_Backend {
 	 * @param bool   $sig_detail  Show details in signature.
 	 * @param string $cache       Cached content.
 	 */
-	public static function print_cache( $sig_detail, $cache );
+	public static function print_cache( bool $sig_detail, $cache ): void;
 }

--- a/inc/class-cachify-cli.php
+++ b/inc/class-cachify-cli.php
@@ -21,7 +21,7 @@ final class Cachify_CLI {
 	 *
 	 * @since 2.3.0
 	 */
-	public static function flush_cache( $args, $assoc_args ) {
+	public static function flush_cache( array $args, array $assoc_args ): void {
 		// Set default arguments.
 		$assoc_args = wp_parse_args( $assoc_args, array( 'all-methods' => false ) );
 
@@ -42,7 +42,7 @@ final class Cachify_CLI {
 	 *
 	 * @since 2.3.0
 	 */
-	public static function get_cache_size( $args, $assoc_args ) {
+	public static function get_cache_size( array $args, array $assoc_args ): void {
 		// Set default arguments.
 		$assoc_args = wp_parse_args( $assoc_args, array( 'raw' => false ) );
 
@@ -62,7 +62,7 @@ final class Cachify_CLI {
 	 *
 	 * @since 2.3.0
 	 */
-	public static function add_commands() {
+	public static function add_commands(): void {
 		// Add flush command.
 		WP_CLI::add_command(
 			'cachify flush',

--- a/inc/class-cachify-db.php
+++ b/inc/class-cachify-db.php
@@ -20,7 +20,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	public static function is_available() {
+	public static function is_available(): bool {
 		return true;
 	}
 
@@ -31,7 +31,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 2.1.2
 	 */
-	public static function stringify_method() {
+	public static function stringify_method(): string {
 		return 'DB';
 	}
 
@@ -45,7 +45,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
+	public static function store_item( string $hash, string $data, int $lifetime, bool $sig_detail ): void {
 		/* Do not store empty data. */
 		if ( empty( $data ) ) {
 			trigger_error( __METHOD__ . ': Empty input.', E_USER_WARNING );
@@ -78,7 +78,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function get_item( $hash ) {
+	public static function get_item( string $hash ) {
 		return get_transient( $hash );
 	}
 
@@ -90,7 +90,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function delete_item( $hash, $url = '' ) {
+	public static function delete_item( string $hash, string $url = '' ): void {
 		delete_transient( $hash );
 	}
 
@@ -99,7 +99,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function clear_cache() {
+	public static function clear_cache(): void {
 		/* Init */
 		global $wpdb;
 
@@ -116,7 +116,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 * @since 2.0
 	 * @since 2.3.0 added $sig_detail parameter
 	 */
-	public static function print_cache( $sig_detail, $cache ) {
+	public static function print_cache( bool $sig_detail, $cache ): void {
 		/* No array? */
 		if ( ! is_array( $cache ) ) {
 			return;
@@ -142,7 +142,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function get_stats() {
+	public static function get_stats(): int {
 		/* Init */
 		global $wpdb;
 
@@ -158,14 +158,14 @@ final class Cachify_DB implements Cachify_Backend {
 	 * Generate signature
 	 *
 	 * @param bool  $detail Show details in signature.
-	 * @param array $meta   Content of metadata.
+	 * @param mixed $meta   Content of metadata.
 	 *
 	 * @return string Signature string
 	 *
 	 * @since 2.0
 	 * @since 2.3.0 added $detail parameter
 	 */
-	private static function _cache_signature( $detail, $meta ) {
+	private static function _cache_signature( bool $detail, $meta ): string {
 		/* No array? */
 		if ( ! is_array( $meta ) ) {
 			return '';
@@ -213,7 +213,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 0.1
 	 */
-	private static function _page_queries() {
+	private static function _page_queries(): int {
 		return $GLOBALS['wpdb']->num_queries;
 	}
 
@@ -224,7 +224,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 0.1
 	 */
-	private static function _page_timer() {
+	private static function _page_timer(): string {
 		return timer_stop( 0, 2 );
 	}
 
@@ -235,7 +235,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 0.7
 	 */
-	private static function _page_memory() {
+	private static function _page_memory(): string {
 		return ( function_exists( 'memory_get_usage' ) ? size_format( memory_get_usage(), 2 ) : 0 );
 	}
 }

--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -20,7 +20,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	public static function is_available() {
+	public static function is_available(): bool {
 		$option = get_option( 'permalink_structure' );
 		return ! empty( $option );
 	}
@@ -32,7 +32,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function is_gzip_enabled() {
+	public static function is_gzip_enabled(): bool {
 		if ( ! function_exists( 'gzencode' ) ) {
 			// GZip is not available on the system.
 			return false;
@@ -53,7 +53,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.1.2
 	 */
-	public static function stringify_method() {
+	public static function stringify_method(): string {
 		return 'HDD';
 	}
 
@@ -68,7 +68,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.0
 	 * @since 2.3.0 added $sig_details parameter
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
+	public static function store_item( string $hash, string $data, int $lifetime, bool $sig_detail ): void {
 		/* Do not store empty data. */
 		if ( empty( $data ) ) {
 			trigger_error( __METHOD__ . ': Empty input.', E_USER_WARNING );
@@ -89,7 +89,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function get_item( $hash ) {
+	public static function get_item( string $hash ) {
 		return is_readable(
 			self::_file_html()
 		);
@@ -103,7 +103,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function delete_item( $hash, $url ) {
+	public static function delete_item( string $hash, string $url ): void {
 		self::_clear_dir(
 			self::_file_path( $url )
 		);
@@ -114,7 +114,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function clear_cache() {
+	public static function clear_cache(): void {
 		self::_clear_dir(
 			CACHIFY_CACHE_DIR,
 			true
@@ -129,7 +129,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function print_cache( $sig_detail, $cache ) {
+	public static function print_cache( bool $sig_detail, $cache ): void {
 		$filename = self::_file_html();
 		$size     = is_readable( $filename ) ? readfile( $filename ) : false;
 
@@ -146,7 +146,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function get_stats() {
+	public static function get_stats(): int {
 		return self::_dir_size( CACHIFY_CACHE_DIR );
 	}
 
@@ -160,7 +160,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.0
 	 * @since 2.3.0 added $detail parameter
 	 */
-	private static function _cache_signature( $detail ) {
+	private static function _cache_signature( bool $detail ): string {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | https://cachify.pluginkollektiv.org',
@@ -179,7 +179,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _create_files( $data ) {
+	private static function _create_files( string $data ): void {
 		$file_path = self::_file_path();
 
 		/* Create directory */
@@ -208,7 +208,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _create_file( $file, $data ) {
+	private static function _create_file( string $file, string $data ): void {
 		/* Writable? */
 		$handle = @fopen( $file, 'wb' );
 		if ( ! $handle ) {
@@ -237,7 +237,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _clear_dir( $dir, $recursive = false ) {
+	private static function _clear_dir( string $dir, bool $recursive = false ): void {
 		// Remove trailing slash.
 		$dir = untrailingslashit( $dir );
 
@@ -289,7 +289,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function _dir_size( $dir = '.' ) {
+	public static function _dir_size( string $dir = '.' ) {
 		/* Is directory? */
 		if ( ! is_dir( $dir ) ) {
 			return false;
@@ -328,13 +328,13 @@ final class Cachify_HDD implements Cachify_Backend {
 	/**
 	 * Path to cache file
 	 *
-	 * @param string $path Request URI or permalink [optional].
+	 * @param string|null $path Request URI or permalink [optional].
 	 *
 	 * @return string Path to cache file
 	 *
 	 * @since 2.0
 	 */
-	private static function _file_path( $path = null ) {
+	private static function _file_path( ?string $path = null ): string {
 		$prefix = is_ssl() ? 'https-' : '';
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
@@ -366,7 +366,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _file_html( $file_path = '' ) {
+	private static function _file_html( string $file_path = '' ): string {
 		return ( empty( $file_path ) ? self::_file_path() : $file_path ) . 'index.html';
 	}
 
@@ -379,7 +379,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _file_gzip( $file_path = '' ) {
+	private static function _file_gzip( string $file_path = '' ): string {
 		return ( empty( $file_path ) ? self::_file_path() : $file_path ) . 'index.html.gz';
 	}
 
@@ -390,7 +390,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @return bool
 	 */
-	private static function _user_can_delete( $file ) {
+	private static function _user_can_delete( string $file ): bool {
 		if ( ! is_file( $file ) && ! is_dir( $file ) ) {
 			return false;
 		}

--- a/inc/class-cachify-memcached.php
+++ b/inc/class-cachify-memcached.php
@@ -29,7 +29,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	public static function is_available() {
+	public static function is_available(): bool {
 		return class_exists( 'Memcached' )
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			&& isset( $_SERVER['SERVER_SOFTWARE'] ) && strpos( strtolower( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ), 'nginx' ) !== false;
@@ -42,7 +42,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.1.2
 	 */
-	public static function stringify_method() {
+	public static function stringify_method(): string {
 		return 'Memcached';
 	}
 
@@ -57,7 +57,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 * @since 2.0.7
 	 * @since 2.3.0 added $sig_detail parameter
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
+	public static function store_item( string $hash, string $data, int $lifetime, bool $sig_detail ): void {
 		/* Do not store empty data. */
 		if ( empty( $data ) ) {
 			trigger_error( __METHOD__ . ': Empty input.', E_USER_WARNING );
@@ -86,7 +86,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	public static function get_item( $hash ) {
+	public static function get_item( string $hash ) {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
 			return null;
@@ -106,7 +106,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	public static function delete_item( $hash, $url = '' ) {
+	public static function delete_item( string $hash, string $url = '' ): void {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
 			return;
@@ -123,7 +123,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	public static function clear_cache() {
+	public static function clear_cache(): void {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
 			return;
@@ -145,7 +145,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	public static function print_cache( $sig_detail, $cache ) {
+	public static function print_cache( bool $sig_detail, $cache ): void {
 		// Not supported.
 	}
 
@@ -191,7 +191,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 * @since 2.0.7
 	 * @since 2.3.0 added $detail parameter
 	 */
-	private static function _cache_signature( $detail ) {
+	private static function _cache_signature( bool $detail ): string {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | https://cachify.pluginkollektiv.org',
@@ -206,13 +206,13 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	/**
 	 * Path of cache file
 	 *
-	 * @param string $path Request URI or permalink [optional].
+	 * @param string|null $path Request URI or permalink [optional].
 	 *
 	 * @return string Path to cache file
 	 *
 	 * @since 2.0.7
 	 */
-	private static function _file_path( $path = null ) {
+	private static function _file_path( ?string $path = null ): string {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$path_parts = wp_parse_url( $path ? $path : wp_unslash( $_SERVER['REQUEST_URI'] ) );
 
@@ -235,7 +235,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	private static function _connect_server() {
+	private static function _connect_server(): bool {
 		/* Not enabled? */
 		if ( ! self::is_available() ) {
 			return false;

--- a/inc/class-cachify-noop.php
+++ b/inc/class-cachify-noop.php
@@ -29,7 +29,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 *
 	 * @param string $unavailable_method Name of the unavailable method.
 	 */
-	public function __construct( $unavailable_method = '' ) {
+	public function __construct( string $unavailable_method = '' ) {
 		$this->unavailable_method = $unavailable_method;
 	}
 
@@ -38,7 +38,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 *
 	 * @return bool TRUE when installed
 	 */
-	public static function is_available() {
+	public static function is_available(): bool {
 		return true;
 	}
 
@@ -47,7 +47,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 *
 	 * @return string Caching method
 	 */
-	public static function stringify_method() {
+	public static function stringify_method(): string {
 		return 'NOOP';
 	}
 
@@ -59,7 +59,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 * @param int    $lifetime Lifetime of the entry.
 	 * @param bool   $sig_detail Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
+	public static function store_item( string $hash, string $data, int $lifetime, bool $sig_detail ): void {
 		// NOOP.
 	}
 
@@ -70,7 +70,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 *
 	 * @return false No content
 	 */
-	public static function get_item( $hash ) {
+	public static function get_item( string $hash ) {
 		return false;
 	}
 
@@ -80,14 +80,14 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 * @param string $hash Hash of the entry.
 	 * @param string $url  URL of the entry [optional].
 	 */
-	public static function delete_item( $hash, $url = '' ) {
+	public static function delete_item( string $hash, string $url = '' ): void {
 		// NOOP.
 	}
 
 	/**
 	 * Clear the cache
 	 */
-	public static function clear_cache() {
+	public static function clear_cache(): void {
 		// NOOP.
 	}
 
@@ -97,7 +97,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 * @param bool  $sig_detail Show details in signature.
 	 * @param array $cache      Array of cache values.
 	 */
-	public static function print_cache( $sig_detail, $cache ) {
+	public static function print_cache( bool $sig_detail, $cache ): void {
 		// NOOP.
 	}
 
@@ -106,7 +106,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	 *
 	 * @return int Column size
 	 */
-	public static function get_stats() {
+	public static function get_stats(): int {
 		return 0;
 	}
 }

--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -25,30 +25,30 @@ final class Cachify_REDIS implements Cachify_Backend {
 	/**
 	 * Availability check
 	 *
-	 * @return  boolean  true/false  TRUE when installed
+	 * @return boolean TRUE when installed
 	 */
-	public static function is_available() {
+	public static function is_available(): bool {
 		return class_exists( 'Redis' );
 	}
 
 	/**
 	 * Caching method as string
 	 *
-	 * @return  string  Caching method
+	 * @return string Caching method
 	 */
-	public static function stringify_method() {
+	public static function stringify_method(): string {
 		return 'Redis';
 	}
 
 	/**
 	 * Store item in cache
 	 *
-	 * @param   string  $hash        Hash  of the entry [ignored].
-	 * @param   string  $data        Content of the entry.
-	 * @param   integer $lifetime    Lifetime of the entry [ignored].
-	 * @param   bool    $sig_detail  Show details in signature.
+	 * @param string  $hash       Hash  of the entry [ignored].
+	 * @param string  $data       Content of the entry.
+	 * @param integer $lifetime   Lifetime of the entry [ignored].
+	 * @param bool    $sig_detail Show details in signature.
 	 */
-	public static function store_item( $hash, $data, $lifetime, $sig_detail ) {
+	public static function store_item( string $hash, string $data, int $lifetime, bool $sig_detail ): void {
 		/* Do not store empty data. */
 		if ( empty( $data ) ) {
 			trigger_error( __METHOD__ . ': Empty input.', E_USER_WARNING );
@@ -71,10 +71,10 @@ final class Cachify_REDIS implements Cachify_Backend {
 	/**
 	 * Read item from cache
 	 *
-	 * @param   string $hash  Hash of the entry.
-	 * @return  mixed         Content of the entry
+	 * @param string $hash Hash of the entry.
+	 * @return mixed Content of the entry
 	 */
-	public static function get_item( $hash ) {
+	public static function get_item( string $hash ) {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
 			return null;
@@ -92,7 +92,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 * @param   string $hash  Hash of the entry [ignored].
 	 * @param   string $url   URL of the entry.
 	 */
-	public static function delete_item( $hash, $url ) {
+	public static function delete_item( string $hash, string $url ): void {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
 			return;
@@ -109,7 +109,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 *
 	 * @return void
 	 */
-	public static function clear_cache() {
+	public static function clear_cache(): void {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
 			return;
@@ -125,7 +125,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 * @param bool   $sig_detail  Show details in signature.
 	 * @param string $cache       Cached content.
 	 */
-	public static function print_cache( $sig_detail, $cache ) {
+	public static function print_cache( bool $sig_detail, $cache ): void {
 		echo $cache;    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		exit;
 	}
@@ -133,9 +133,9 @@ final class Cachify_REDIS implements Cachify_Backend {
 	/**
 	 * Get the cache size
 	 *
-	 * @return  integer  Directory size
+	 * @return integer Directory size
 	 */
-	public static function get_stats() {
+	public static function get_stats(): ?int {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
 			return null;
@@ -160,10 +160,10 @@ final class Cachify_REDIS implements Cachify_Backend {
 	/**
 	 * Generate signature
 	 *
-	 * @param   bool $detail  Show details in signature.
-	 * @return  string        Signature string
+	 * @param bool $detail Show details in signature.
+	 * @return string Signature string
 	 */
-	private static function _cache_signature( $detail ) {
+	private static function _cache_signature( bool $detail ): string {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | https://cachify.pluginkollektiv.org',
@@ -178,10 +178,10 @@ final class Cachify_REDIS implements Cachify_Backend {
 	/**
 	 * Path of cache file
 	 *
-	 * @param   string $path  Request URI or permalink [optional].
-	 * @return  string        Path to cache file
+	 * @param string|null $path Request URI or permalink [optional].
+	 * @return string Path to cache file
 	 */
-	private static function _file_path( $path = null ) {
+	private static function _file_path( ?string $path = null ): string {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$path_parts = wp_parse_url( $path ? $path : wp_unslash( $_SERVER['REQUEST_URI'] ) );
 
@@ -198,9 +198,9 @@ final class Cachify_REDIS implements Cachify_Backend {
 	/**
 	 * Connect to Redis server
 	 *
-	 * @return  boolean  true/false  TRUE on success
+	 * @return boolean TRUE on success
 	 */
-	private static function _connect_server() {
+	private static function _connect_server(): bool {
 		/* Not enabled? */
 		if ( ! self::is_available() ) {
 			return false;

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -138,14 +138,8 @@ final class Cachify {
 
 		if ( is_admin() ) {
 			/* Backend */
-			if ( version_compare( get_bloginfo( 'version' ), '5.1', '<' ) ) {
-				// The following hooks are deprecated since WP 5.1 (#246).
-				add_action( 'wpmu_new_blog', array( __CLASS__, 'install_later' ) );
-				add_action( 'delete_blog', array( __CLASS__, 'uninstall_later' ) );
-			} else {
-				add_action( 'wp_initialize_site', array( __CLASS__, 'install_later' ) );
-				add_action( 'wp_delete_site', array( __CLASS__, 'uninstall_later' ) );
-			}
+			add_action( 'wp_initialize_site', array( __CLASS__, 'install_later' ) );
+			add_action( 'wp_delete_site', array( __CLASS__, 'uninstall_later' ) );
 
 			add_action( 'admin_init', array( __CLASS__, 'register_textdomain' ) );
 
@@ -215,19 +209,20 @@ final class Cachify {
 	/**
 	 * Plugin installation on new WPMS site.
 	 *
-	 * @param int|WP_Site $new_site New site ID or object.
+	 * @param WP_Site $new_site New site ID or object.
 	 *
 	 * @since 1.0
 	 * @since 2.4.0 supports WP_Site argument
+	 * @since 2.5.0 no longer supports int argument
 	 */
-	public static function install_later( $new_site ): void {
+	public static function install_later( WP_Site $new_site ): void {
 		/* No network plugin */
 		if ( ! is_plugin_active_for_network( CACHIFY_BASE ) ) {
 			return;
 		}
 
 		/* Switch to blog */
-		switch_to_blog( is_int( $new_site ) ? $new_site : $new_site->blog_id );
+		switch_to_blog( $new_site->blog_id );
 
 		/* Install */
 		self::_install_backend();
@@ -284,19 +279,20 @@ final class Cachify {
 	/**
 	 * Uninstalling of the plugin for WPMS site.
 	 *
-	 * @param int|WP_Site $old_site Old site ID or object.
+	 * @param WP_Site $old_site Old site ID or object.
 	 *
 	 * @since 1.0
 	 * @since 2.4.0 supports WP_Site argument
+	 * @since 2.5.0 no longer supports int argument
 	 */
-	public static function uninstall_later( $old_site ): void {
+	public static function uninstall_later( WP_Site $old_site ): void {
 		/* No network plugin */
 		if ( ! is_plugin_active_for_network( CACHIFY_BASE ) ) {
 			return;
 		}
 
 		/* Switch to blog */
-		switch_to_blog( is_int( $old_site ) ? $old_site : $old_site->blog_id );
+		switch_to_blog( $old_site->blog_id );
 
 		/* Install */
 		self::_uninstall_backend();

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -77,8 +77,8 @@ final class Cachify {
 	 *
 	 * @since 2.0.5
 	 */
-	public static function instance() {
-		new self();
+	public static function instance(): self {
+		return new self();
 	}
 
 	/**
@@ -175,7 +175,7 @@ final class Cachify {
 	 *
 	 * @since 2.1.0
 	 */
-	public static function on_deactivation() {
+	public static function on_deactivation(): void {
 		/* Remove hdd cache cron when hdd is selected */
 		if ( self::METHOD_HDD === self::$options['use_apc'] ) {
 			$timestamp = wp_next_scheduled( 'hdd_cache_cron' );
@@ -192,7 +192,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	public static function on_activation() {
+	public static function on_activation(): void {
 		/* Multisite & Network */
 		if ( is_multisite() && ! empty( $_GET['networkwide'] ) ) {
 			/* Blog IDs */
@@ -220,7 +220,7 @@ final class Cachify {
 	 * @since 1.0
 	 * @since 2.4.0 supports WP_Site argument
 	 */
-	public static function install_later( $new_site ) {
+	public static function install_later( $new_site ): void {
 		/* No network plugin */
 		if ( ! is_plugin_active_for_network( CACHIFY_BASE ) ) {
 			return;
@@ -241,7 +241,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	private static function _install_backend() {
+	private static function _install_backend(): void {
 		add_option(
 			'cachify',
 			array()
@@ -256,7 +256,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	public static function on_uninstall() {
+	public static function on_uninstall(): void {
 		/* Global */
 		global $wpdb;
 
@@ -289,7 +289,7 @@ final class Cachify {
 	 * @since 1.0
 	 * @since 2.4.0 supports WP_Site argument
 	 */
-	public static function uninstall_later( $old_site ) {
+	public static function uninstall_later( $old_site ): void {
 		/* No network plugin */
 		if ( ! is_plugin_active_for_network( CACHIFY_BASE ) ) {
 			return;
@@ -310,7 +310,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	private static function _uninstall_backend() {
+	private static function _uninstall_backend(): void {
 		/* Option */
 		delete_option( 'cachify' );
 
@@ -325,7 +325,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	private static function _get_blog_ids() {
+	private static function _get_blog_ids(): array {
 		/* Global */
 		global $wpdb;
 
@@ -337,7 +337,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function register_styles() {
+	public static function register_styles(): void {
 		/* Register dashboard CSS */
 		wp_register_style(
 			'cachify-dashboard',
@@ -360,7 +360,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function register_scripts() {
+	public static function register_scripts(): void {
 		/* Register admin bar flush script */
 		wp_register_script(
 			'cachify-admin-bar-flush',
@@ -376,7 +376,7 @@ final class Cachify {
 	 *
 	 * @since 2.1.3
 	 */
-	public static function register_textdomain() {
+	public static function register_textdomain(): void {
 		load_plugin_textdomain( 'cachify' );
 	}
 
@@ -385,7 +385,7 @@ final class Cachify {
 	 *
 	 * @since 2.0
 	 */
-	private static function _set_default_vars() {
+	private static function _set_default_vars(): void {
 		/* Options */
 		self::$options = self::_get_options();
 
@@ -428,7 +428,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function admin_notice_unavailable() {
+	public static function admin_notice_unavailable(): void {
 		if ( current_user_can( 'manage_options' ) ) {
 			$unavailable_method = '-';
 			if ( self::$method instanceof Cachify_NOOP ) {
@@ -464,7 +464,7 @@ final class Cachify {
 	 *
 	 * @since 2.0
 	 */
-	private static function _get_options() {
+	private static function _get_options(): array {
 		return wp_parse_args(
 			get_option( 'cachify' ),
 			array(
@@ -490,7 +490,7 @@ final class Cachify {
 	 * @since 1.0
 	 * @since 2.1.9
 	 */
-	public static function robots_txt( $output ) {
+	public static function robots_txt( string $output ): string {
 		if ( ! self::$options['change_robots_txt'] ) {
 			return $output;
 		}
@@ -507,7 +507,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function run_hdd_cache_cron() {
+	public static function run_hdd_cache_cron(): void {
 		Cachify_HDD::clear_cache();
 	}
 
@@ -520,7 +520,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function add_cron_cache_expiration( $schedules ) {
+	public static function add_cron_cache_expiration( array $schedules ): array {
 		$schedules['cachify_cache_expire'] = array(
 			'interval' => self::$options['cache_expires'] * 3600,
 			'display'  => esc_html__( 'Cachify expire', 'cachify' ),
@@ -537,7 +537,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	public static function action_links( $data ) {
+	public static function action_links( array $data ): array {
 		/* Permissions? */
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return $data;
@@ -570,7 +570,7 @@ final class Cachify {
 	 *
 	 * @since 0.5
 	 */
-	public static function row_meta( $input, $page ) {
+	public static function row_meta( array $input, string $page ): array {
 		/* Permissions */
 		if ( CACHIFY_BASE !== $page ) {
 			return $input;
@@ -594,7 +594,7 @@ final class Cachify {
 	 *
 	 * @since 2.0.0
 	 */
-	public static function add_dashboard_count( $items = array() ) {
+	public static function add_dashboard_count( array $items = array() ): array {
 		/* Skip */
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return $items;
@@ -653,7 +653,7 @@ final class Cachify {
 	 *
 	 * @since 2.0.6
 	 */
-	public static function get_cache_size() {
+	public static function get_cache_size(): int {
 		$size = get_transient( 'cachify_cache_size' );
 		if ( ! $size ) {
 			/* Read */
@@ -680,13 +680,13 @@ final class Cachify {
 	 *
 	 * @hook    mixed cachify_user_can_flush_cache
 	 *
-	 * @param object $wp_admin_bar Object of menu items.
+	 * @param WP_Admin_Bar $wp_admin_bar Object of menu items.
 	 *
 	 * @since 1.2
 	 * @since 2.2.2
 	 * @since 2.4.0 Adjust icon for flush request via AJAX
 	 */
-	public static function add_flush_icon( $wp_admin_bar ) {
+	public static function add_flush_icon( WP_Admin_Bar $wp_admin_bar ): void {
 		/* Quit */
 		if ( ! is_admin_bar_showing() || ! apply_filters( 'cachify_user_can_flush_cache', current_user_can( 'manage_options' ) ) ) {
 			return;
@@ -727,7 +727,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function get_dashicon_success_class() {
+	public static function get_dashicon_success_class(): string {
 		global $wp_version;
 		if ( version_compare( $wp_version, '5.2', '<' ) ) {
 			return 'dashicons-yes';
@@ -743,7 +743,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function add_flush_icon_script() {
+	public static function add_flush_icon_script(): void {
 		/* Quit */
 		if ( ! is_admin_bar_showing() || ! apply_filters( 'cachify_user_can_flush_cache', current_user_can( 'manage_options' ) ) ) {
 			return;
@@ -775,7 +775,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function add_flush_rest_endpoint() {
+	public static function add_flush_rest_endpoint(): void {
 		register_rest_route(
 			self::REST_NAMESPACE,
 			self::REST_ROUTE_FLUSH,
@@ -800,7 +800,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function user_can_manage_options() {
+	public static function user_can_manage_options(): bool {
 		return current_user_can( 'manage_options' );
 	}
 
@@ -809,13 +809,13 @@ final class Cachify {
 	 *
 	 * @hook    mixed  cachify_user_can_flush_cache
 	 *
-	 * @param array $data Metadata of the plugin.
+	 * @param array|string $data Metadata of the plugin.
 	 *
 	 * @since 0.5
 	 * @since 2.2.2
 	 * @since 2.4.0  Extract cache flushing to own method and always redirect to referer with new value for `_cachify` param.
 	 */
-	public static function process_flush_request( $data ) {
+	public static function process_flush_request( $data ): void {
 		/* Skip if not a flush request */
 		if ( empty( $_GET['_cachify'] ) || 'flush' !== $_GET['_cachify'] ) {
 			return;
@@ -855,7 +855,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function flush_cache() {
+	public static function flush_cache(): void {
 		/* Flush cache */
 		if ( is_multisite() && is_network_admin() ) {
 			/* Old blog */
@@ -915,7 +915,7 @@ final class Cachify {
 	 * @since 1.2
 	 * @since 2.2.2
 	 */
-	public static function flush_notice() {
+	public static function flush_notice(): void {
 		/* No admin */
 		if ( ! is_admin_bar_showing() || ! apply_filters( 'cachify_user_can_flush_cache', current_user_can( 'manage_options' ) ) ) {
 			return;
@@ -937,7 +937,7 @@ final class Cachify {
 	 *
 	 * @deprecated 2.4.0 Use comment_edit($id, $comment) instead.
 	 */
-	public static function edit_comment( $id ) {
+	public static function edit_comment( int $id ) {
 		self::comment_edit( $id, array( 'comment_approved' => 1 ) );
 	}
 
@@ -949,7 +949,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0 Replacement for edit_comment($id) with additional comment parameter.
 	 */
-	public static function comment_edit( $id, $comment ) {
+	public static function comment_edit( int $id, array $comment ): void {
 		$approved = (int) $comment['comment_approved'];
 
 		/* Approved comment? */
@@ -976,7 +976,7 @@ final class Cachify {
 	 * @since 2.1.2
 	 * @since 2.4.0 Replacement for edit_comment($id) with additional comment parameter.
 	 */
-	public static function pre_comment( $approved, $comment ) {
+	public static function pre_comment( $approved, array $comment ) {
 		self::new_comment( $comment['comment_ID'], $approved );
 
 		return $approved;
@@ -992,7 +992,7 @@ final class Cachify {
 	 * @since 2.1.2
 	 * @since 2.4.0 Renamed with ID parameter instead of comment array.
 	 */
-	public static function new_comment( $id, $approved ) {
+	public static function new_comment( $id, $approved ): void {
 		/* Approved comment? */
 		if ( 1 === $approved ) {
 			if ( self::$options['reset_on_comment'] ) {
@@ -1006,16 +1006,16 @@ final class Cachify {
 	/**
 	 * Remove page from cache or flush on comment edit
 	 *
-	 * @param string $new_status New status.
-	 * @param string $old_status Old status.
-	 * @param object $comment    The comment.
+	 * @param string     $new_status New status.
+	 * @param string     $old_status Old status.
+	 * @param WP_Comment $comment    The comment.
 	 *
 	 * @since 0.1
 	 * @since 2.1.2
 	 *
 	 * @deprecated 2.4.0 Use comment_status($new_status, $old_status, $comment) instead.
 	 */
-	public static function touch_comment( $new_status, $old_status, $comment ) {
+	public static function touch_comment( string $new_status, string $old_status, WP_Comment $comment ): void {
 		self::comment_status( $new_status, $old_status, $comment );
 	}
 
@@ -1030,7 +1030,7 @@ final class Cachify {
 	 * @since 2.1.2
 	 * @since 2.4.0 Renamed from touch_comment().
 	 */
-	public static function comment_status( $new_status, $old_status, $comment ) {
+	public static function comment_status( string $new_status, string $old_status, WP_Comment $comment ): void {
 		if ( 'approved' === $old_status || 'approved' === $new_status ) {
 			if ( self::$options['reset_on_comment'] ) {
 				self::flush_total_cache();
@@ -1048,7 +1048,7 @@ final class Cachify {
 	 *
 	 * @deprecated no longer used since 2.4
 	 */
-	public static function register_publish_hooks() {
+	public static function register_publish_hooks(): void {
 		/* Available post types */
 		$post_types = get_post_types(
 			array(
@@ -1071,14 +1071,14 @@ final class Cachify {
 	/**
 	 * Removes the post type cache on post updates
 	 *
-	 * @param int    $post_id Post ID.
-	 * @param object $post    Post object.
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
 	 *
 	 * @since 2.0.3
 	 *
 	 * @deprecated no longer used since 2.4
 	 */
-	public static function publish_post_types( $post_id, $post ) {
+	public static function publish_post_types( int $post_id, WP_Post $post ): void {
 		/* No post_id? */
 		if ( empty( $post_id ) || empty( $post ) ) {
 			return;
@@ -1113,7 +1113,7 @@ final class Cachify {
 	 * @since 2.1.7 Make the function public.
 	 * @since 2.4.0 Renamed to save_update_trash_post and introduced parameters.
 	 */
-	public static function save_update_trash_post( $id, $post_after, $post_before ) {
+	public static function save_update_trash_post( int $id, WP_Post $post_after, WP_Post $post_before ): void {
 		$status = get_post_status( $post_before );
 
 		/* Post type published? */
@@ -1132,7 +1132,7 @@ final class Cachify {
 	 * @since 2.3.0
 	 * @since 2.4.0 Renamed to post_update.
 	 */
-	public static function post_update( $id, $data ) {
+	public static function post_update( int $id, array $data ): void {
 		$new_status = $data['post_status'];
 		$old_status = get_post_status( $id );
 
@@ -1149,7 +1149,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function flush_cache_for_posts( $post ) {
+	public static function flush_cache_for_posts( $post ): void {
 		if ( is_int( $post ) ) {
 			$post_id = $post;
 			$data    = get_post( $post_id );
@@ -1178,7 +1178,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function flush_woocommerce( $product ) {
+	public static function flush_woocommerce( $product ): void {
 		if ( is_int( $product ) ) {
 			$id = $product;
 		} else {
@@ -1195,8 +1195,7 @@ final class Cachify {
 	 *
 	 * @since 2.0.3
 	 */
-	public static function remove_page_cache_by_post_id( $post_id ) {
-		$post_id = (int) $post_id;
+	public static function remove_page_cache_by_post_id( int $post_id ): void {
 		if ( ! $post_id ) {
 			return;
 		}
@@ -1211,9 +1210,8 @@ final class Cachify {
 	 *
 	 * @since 0.1
 	 */
-	public static function remove_page_cache_by_url( $url ) {
-		$url = (string) $url;
-		if ( ! $url ) {
+	public static function remove_page_cache_by_url( string $url ): void {
+		if ( empty( $url ) ) {
 			return;
 		}
 
@@ -1238,7 +1236,7 @@ final class Cachify {
 	 *
 	 * @since 2.0.0
 	 */
-	private static function _cache_expires() {
+	private static function _cache_expires(): int {
 		return HOUR_IN_SECONDS * self::$options['cache_expires'];
 	}
 
@@ -1249,7 +1247,7 @@ final class Cachify {
 	 *
 	 * @since 2.3.0
 	 */
-	private static function _signature_details() {
+	private static function _signature_details(): bool {
 		return 1 === self::$options['sig_detail'];
 	}
 
@@ -1263,7 +1261,7 @@ final class Cachify {
 	 * @since 0.1
 	 * @since 2.0
 	 */
-	private static function _cache_hash( $url = '' ) {
+	private static function _cache_hash( string $url = '' ): string {
 		$prefix = is_ssl() ? 'https-' : '';
 
 		if ( empty( $url ) ) {
@@ -1287,7 +1285,7 @@ final class Cachify {
 	 * @since 0.9.1
 	 * @since 1.0
 	 */
-	private static function _preg_split( $input ) {
+	private static function _preg_split( string $input ): array {
 		return (array) preg_split( '/,/', $input, -1, PREG_SPLIT_NO_EMPTY );
 	}
 
@@ -1298,7 +1296,7 @@ final class Cachify {
 	 *
 	 * @since 0.6
 	 */
-	private static function _is_index() {
+	private static function _is_index(): bool {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		return basename( wp_unslash( $_SERVER['SCRIPT_NAME'] ) ) === 'index.php';
 	}
@@ -1310,7 +1308,7 @@ final class Cachify {
 	 *
 	 * @since 0.9.1
 	 */
-	private static function _is_mobile() {
+	private static function _is_mobile(): bool {
 		$templatedir = get_template_directory();
 		return ( strpos( $templatedir, 'wptouch' ) || strpos( $templatedir, 'carrington' ) || strpos( $templatedir, 'jetpack' ) || strpos( $templatedir, 'handheld' ) );
 	}
@@ -1322,7 +1320,7 @@ final class Cachify {
 	 *
 	 * @since 2.0.0
 	 */
-	private static function _is_logged_in() {
+	private static function _is_logged_in(): bool {
 		/* Logged in */
 		if ( is_user_logged_in() ) {
 			return true;
@@ -1348,7 +1346,7 @@ final class Cachify {
 	 *
 	 * @since 2.4.0
 	 */
-	public static function register_flush_cache_hooks() {
+	public static function register_flush_cache_hooks(): void {
 		/* Define all default flush cache hooks */
 		$flush_cache_hooks = array(
 			'cachify_flush_cache'            => 10,
@@ -1383,7 +1381,7 @@ final class Cachify {
 	 *
 	 * @since 0.2
 	 */
-	private static function _skip_cache() {
+	private static function _skip_cache(): bool {
 
 		/* Plugin options */
 		$options = self::$options;
@@ -1471,7 +1469,7 @@ final class Cachify {
 	 *
 	 * @since 0.9.2
 	 */
-	private static function _minify_cache( $data ) {
+	private static function _minify_cache( string $data ): string {
 		/* Disabled? */
 		if ( ! self::$options['compress_html'] ) {
 			return $data;
@@ -1533,7 +1531,7 @@ final class Cachify {
 	 * @since 0.1
 	 * @since 2.0
 	 */
-	public static function flush_total_cache( $clear_all_methods = false ) {
+	public static function flush_total_cache( bool $clear_all_methods = false ): void {
 		// We do not need to flush the cache for saved post revisions.
 		if ( did_action( 'save_post_revision' ) ) {
 			return;
@@ -1578,7 +1576,7 @@ final class Cachify {
 	 * @since 0.1
 	 * @since 2.0
 	 */
-	public static function set_cache( $data ) {
+	public static function set_cache( string $data ): string {
 		/* Empty? */
 		if ( empty( $data ) ) {
 			return '';
@@ -1638,7 +1636,7 @@ final class Cachify {
 	 *
 	 * @since 0.1
 	 */
-	public static function manage_cache() {
+	public static function manage_cache(): void {
 		/* No caching? */
 		if ( self::_skip_cache() ) {
 			return;
@@ -1677,7 +1675,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	public static function add_admin_resources( $hook ) {
+	public static function add_admin_resources( string $hook ): void {
 		// Add flush icon script and style to admin bar.
 		self::add_flush_icon_script();
 
@@ -1702,7 +1700,7 @@ final class Cachify {
 	 *
 	 * @since 2.3.0
 	 */
-	public static function admin_dashboard_styles() {
+	public static function admin_dashboard_styles(): void {
 		$wp_version = get_bloginfo( 'version' );
 
 		if ( version_compare( $wp_version, '5.3', '<' ) ) {
@@ -1717,7 +1715,7 @@ final class Cachify {
 	 *
 	 * @deprecated included in dashboard.css since 2.4
 	 */
-	public static function admin_dashboard_dark_mode_styles() {
+	public static function admin_dashboard_dark_mode_styles(): void {
 		wp_add_inline_style( 'cachify-dashboard', '#dashboard_right_now .cachify-icon use { fill: #bbc8d4; }' );
 	}
 
@@ -1726,7 +1724,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	public static function add_page() {
+	public static function add_page(): void {
 		add_options_page(
 			__( 'Cachify', 'cachify' ),
 			__( 'Cachify', 'cachify' ),
@@ -1744,7 +1742,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	public static function register_settings() {
+	public static function register_settings(): void {
 		register_setting(
 			'cachify',
 			'cachify',
@@ -1765,7 +1763,7 @@ final class Cachify {
 	 * @since 1.0
 	 * @since 2.1.3
 	 */
-	public static function validate_options( $data ) {
+	public static function validate_options( array $data ): array {
 		/* Empty data? */
 		if ( empty( $data ) ) {
 			return array();
@@ -1804,7 +1802,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	public static function options_page() {
+	public static function options_page(): void {
 		$options      = self::_get_options();
 		$cachify_tabs = self::_get_tabs( $options );
 		$current_tab  = isset( $_GET['cachify_tab'] ) && isset( $cachify_tabs[ $_GET['cachify_tab'] ] )
@@ -1857,7 +1855,7 @@ final class Cachify {
 	 *
 	 * @since 2.3.0
 	 */
-	private static function _get_tabs( $options ) {
+	private static function _get_tabs( array $options ): array {
 		/* Settings tab is always present */
 		$tabs = array(
 			'settings' => array(

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1788,7 +1788,7 @@ final class Cachify {
 		return array(
 			'only_guests'       => (int) ( ! empty( $data['only_guests'] ) ),
 			'compress_html'     => (int) $data['compress_html'],
-			'cache_expires'     => (int) ( isset( $data['cache_expires'] ) ? $data['cache_expires'] : self::$options['cache_expires'] ),
+			'cache_expires'     => (int) ( $data['cache_expires'] ?? self::$options['cache_expires'] ),
 			'without_ids'       => (string) isset( $data['without_ids'] ) ? sanitize_text_field( $data['without_ids'] ) : '',
 			'without_agents'    => (string) isset( $data['without_agents'] ) ? sanitize_text_field( $data['without_agents'] ) : '',
 			'use_apc'           => (int) $data['use_apc'],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,7 +20,7 @@
     <exclude-pattern>vendor/*</exclude-pattern>
 
     <!-- WordPress coding standards -->
-    <config name="minimum_supported_wp_version" value="4.7"/>
+    <config name="minimum_supported_wp_version" value="5.1"/>
     <rule ref="WordPress">
         <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
@@ -33,6 +33,6 @@
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
-    <config name="testVersion" value="5.6-"/>
+    <config name="testVersion" value="7.2-"/>
     <rule ref="PHPCompatibilityWP"/>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 * Contributors:      pluginkollektiv
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Tags:              cache, caching, performance, optimize, speed
-* Requires at least: 4.7
+* Requires at least: 5.1
 * Tested up to:      6.8
-* Requires PHP:      5.6
+* Requires PHP:      7.2
 * Stable tag:        2.4.2
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Drop support for PHP 5.6-7.1 and WordPress 4.7-5.0.
This makes development easier and should not be a big deal for most sites.

To make a point:

- remove old dev-dependencies
- use PHP 7 null-coalescing operator (`??`) where applicable
- add PHP type hints to all methods
- remove legacy multisite hooks for WP before 5.1