### PR TITLE
Use prefixed Redis keys to prevent data loss on cache clearing.

### DIFF
--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -116,6 +116,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 		}
 
 		/* Delete all cache entries for this site */
+
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$host = wp_unslash( $_SERVER['HTTP_HOST'] );
 		$keys = self::$redis->keys( $host . '*' );

--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -115,8 +115,21 @@ final class Cachify_REDIS implements Cachify_Backend {
 			return;
 		}
 
-		/* Flush */
-		@self::$_redis->flushAll();
+		/* Delete all cache entries for this site */
+		$host = wp_unslash( $_SERVER['HTTP_HOST'] );
+		$keys = self::$_redis->keys( $host . '*' );
+
+		if ( $keys ) {
+			$prefix = self::$_redis->getOption( Redis::OPT_PREFIX );
+
+			// Strip the prefix from the keys, as phpredis' unlink() will add it again.
+			$stripped_keys = array_map(
+				function ( $key ) use ( $prefix ) {
+					return preg_replace( "/^${prefix}/", '', $key );
+				}, $keys
+			);
+			self::$_redis->unlink( $stripped_keys );
+		}
 	}
 
 	/**
@@ -237,6 +250,9 @@ final class Cachify_REDIS implements Cachify_Backend {
 			if ( ! self::$_redis->isConnected() ) {
 				return false;
 			}
+
+			// Automatically prefix the Redis keys for all operations.
+			self::$_redis->setOption( Redis::OPT_PREFIX, 'cachify:' );
 		} catch ( Exception $e ) {
 			return false;
 		}

--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -116,6 +116,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 		}
 
 		/* Delete all cache entries for this site */
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$host = wp_unslash( $_SERVER['HTTP_HOST'] );
 		$keys = self::$_redis->keys( $host . '*' );
 
@@ -126,7 +127,8 @@ final class Cachify_REDIS implements Cachify_Backend {
 			$stripped_keys = array_map(
 				function ( $key ) use ( $prefix ) {
 					return preg_replace( "/^${prefix}/", '', $key );
-				}, $keys
+				},
+				$keys
 			);
 			self::$_redis->unlink( $stripped_keys );
 		}


### PR DESCRIPTION
Only cachify entries that belong to the current host are removed from the cache.