### PR TITLE
merge hooks for flush icon style and script and use plugin version instead of filemtime

### DIFF
--- a/cachify.php
+++ b/cachify.php
@@ -41,6 +41,7 @@ define( 'CACHIFY_FILE', __FILE__ );
 define( 'CACHIFY_DIR', __DIR__ );
 define( 'CACHIFY_BASE', plugin_basename( __FILE__ ) );
 define( 'CACHIFY_CACHE_DIR', WP_CONTENT_DIR . '/cache/cachify' );
+define( 'CACHIFY_VERSION', '2.4.1' );
 
 
 /* Hooks */

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -117,7 +117,7 @@ final class Cachify {
 		add_action( 'admin_bar_menu', array( __CLASS__, 'add_flush_icon' ), 90 );
 
 		/* Flush icon script */
-		add_action( 'admin_bar_menu', array( __CLASS__, 'add_flush_icon_script' ), 90 );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'add_flush_icon_script' ) );
 
 		/* Flush REST endpoint */
 		add_action( 'rest_api_init', array( __CLASS__, 'add_flush_rest_endpoint' ) );
@@ -692,9 +692,6 @@ final class Cachify {
 			return;
 		}
 
-		/* Enqueue style */
-		wp_enqueue_style( 'cachify-admin-bar-flush' );
-
 		/* Print area for aria live updates */
 		echo '<span class="ab-aria-live-area screen-reader-text" aria-live="polite"></span>';
 		/* Check if the flush action was used without AJAX */
@@ -742,17 +739,18 @@ final class Cachify {
 	/**
 	 * Add a script to query the REST endpoint and animate the flush icon in admin bar menu
 	 *
-	 * @hook  mixed  cachify_user_can_flush_cache ?
-	 *
-	 * @param object $wp_admin_bar Object of menu items.
+	 * @hook cachify_user_can_flush_cache
 	 *
 	 * @since 2.4.0
 	 */
-	public static function add_flush_icon_script( $wp_admin_bar ) {
+	public static function add_flush_icon_script() {
 		/* Quit */
 		if ( ! is_admin_bar_showing() || ! apply_filters( 'cachify_user_can_flush_cache', current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
+
+		/* Enqueue style */
+		wp_enqueue_style( 'cachify-admin-bar-flush' );
 
 		/* Enqueue script */
 		wp_enqueue_script( 'cachify-admin-bar-flush' );
@@ -1680,6 +1678,9 @@ final class Cachify {
 	 * @since 1.0
 	 */
 	public static function add_admin_resources( $hook ) {
+		// Add flush icon script and style to admin bar.
+		self::add_flush_icon_script();
+
 		/* Hooks check */
 		if ( 'index.php' !== $hook && 'settings_page_cachify' !== $hook ) {
 			return;

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -343,7 +343,7 @@ final class Cachify {
 			'cachify-dashboard',
 			plugins_url( 'css/dashboard.min.css', CACHIFY_FILE ),
 			array(),
-			filemtime( plugin_dir_path( CACHIFY_FILE ) . 'css/dashboard.min.css' )
+			CACHIFY_VERSION
 		);
 
 		/* Register admin bar flush CSS */
@@ -351,7 +351,7 @@ final class Cachify {
 			'cachify-admin-bar-flush',
 			plugins_url( 'css/admin-bar-flush.min.css', CACHIFY_FILE ),
 			array(),
-			filemtime( plugin_dir_path( CACHIFY_FILE ) . 'css/admin-bar-flush.min.css' )
+			CACHIFY_VERSION
 		);
 	}
 
@@ -366,7 +366,7 @@ final class Cachify {
 			'cachify-admin-bar-flush',
 			plugins_url( 'js/admin-bar-flush.min.js', CACHIFY_FILE ),
 			array(),
-			filemtime( plugin_dir_path( CACHIFY_FILE ) . 'js/admin-bar-flush.min.js' ),
+			CACHIFY_VERSION,
 			true
 		);
 	}

--- a/js/admin-bar-flush.js
+++ b/js/admin-bar-flush.js
@@ -1,8 +1,14 @@
 /* global cachify_admin_bar_flush_ajax_object */
-( function() {
-	var is_flushing = false,
-		admin_bar_cachify_list_item = document.getElementById( 'wp-admin-bar-cachify' ),
-		flush_link = admin_bar_cachify_list_item.querySelector( 'a.ab-item' ),
+document.addEventListener( 'DOMContentLoaded', function() {
+	var is_flushing = false;
+	var admin_bar_cachify_list_item = document.getElementById( 'wp-admin-bar-cachify' );
+
+	if ( ! admin_bar_cachify_list_item ) {
+		// Admin bar item is not present in DOM, exit here.
+		return;
+	}
+
+	var flush_link = admin_bar_cachify_list_item.querySelector( 'a.ab-item' ),
 		fallback_url = flush_link.getAttribute( 'href' ),
 		aria_live_area = document.querySelector( '.ab-aria-live-area' );
 
@@ -80,4 +86,4 @@
 		request.setRequestHeader( 'X-WP-Nonce', cachify_admin_bar_flush_ajax_object.nonce );
 		request.send();
 	}
-}() );
+} );


### PR DESCRIPTION
Fixes and sideshows of #312.

We have a `admin_bar_menu` hook to add the "flush cache" icon including stylesheet and another hook in the same phase to add the script.
We also determine file modification times of all 3 resources using `filemtime()` on the CSS/JS file.
And finally, a possible race condition inside the Javascript, if the icon is not rendered before script excution.

1. Append constant `CACHIFY_VERSION` instead of dynamic timestamps.
2. Merge script and style hooks and move them to `wp_enqueue_scripts`/`admin_qneueue_scripts` phase.
3. Rework JS to use `DOMContentLoaded´ event listener.


