### PR TITLE
refactor: introduce a static void function init() instead of constructor

### DIFF
--- a/cachify.php
+++ b/cachify.php
@@ -49,7 +49,7 @@ add_action(
 	'plugins_loaded',
 	array(
 		'Cachify',
-		'instance',
+		'init',
 	)
 );
 register_activation_hook(

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -76,17 +76,19 @@ final class Cachify {
 	 * Pseudo constructor
 	 *
 	 * @since 2.0.5
+	 * @deprecated Use {@link init()} instead, construction is not required.
 	 */
 	public static function instance(): self {
+		self::init();
 		return new self();
 	}
 
 	/**
-	 * Constructor
+	 * Initialize the plugin.
 	 *
-	 * @since 1.0
+	 * @since 2.5.0 Logic extracted from constructor as a replacement for "instance()" without return value.
 	 */
-	public function __construct() {
+	public static function init(): void {
 		/* Set defaults */
 		self::_set_default_vars();
 

--- a/tests/test-cachify.php
+++ b/tests/test-cachify.php
@@ -121,7 +121,7 @@ class Test_Cachify extends WP_UnitTestCase {
 				'change_robots_txt' => 1,
 			)
 		);
-		new Cachify();
+		Cachify::init();
 
 		self::assertEquals(
 			$robots_txt,
@@ -137,7 +137,7 @@ class Test_Cachify extends WP_UnitTestCase {
 				'change_robots_txt' => 1,
 			)
 		);
-		new Cachify();
+		Cachify::init();
 
 		self::assertEquals(
 			$robots_txt . "\nUser-agent: *\nDisallow: */cache/cachify/\n",


### PR DESCRIPTION
Calling `instance() `constructs an unused `Cachify` instance. Extract the (static) logic from the constructor into a new void methd `init()` and use it as initialization hook.