### PR TITLE
refactor: remove redundant empty-check in publish_post_types hook

### DIFF
--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -1077,11 +1077,6 @@ final class Cachify {
 	 * @deprecated no longer used since 2.4
 	 */
 	public static function publish_post_types( int $post_id, WP_Post $post ): void {
-		/* No post_id? */
-		if ( empty( $post_id ) || empty( $post ) ) {
-			return;
-		}
-
 		/* Post status check */
 		if ( ! in_array( $post->post_status, array( 'publish', 'future' ), true ) ) {
 			return;


### PR DESCRIPTION
Both `$post_id` and `$post should` always be populated by contract of the `{$new_status}_{$post->post_type}` hook [1] and enforced by type hints.

----

[1] https://developer.wordpress.org/reference/hooks/new_status_post-post_type/