### PR TITLE
call backend methods directly instead of call_user_func

### DIFF
--- a/inc/class-cachify-backend.php
+++ b/inc/class-cachify-backend.php
@@ -65,4 +65,11 @@ interface Cachify_Backend {
 	 * @param string $cache       Cached content.
 	 */
 	public static function print_cache( bool $sig_detail, $cache ): void;
+
+	/**
+	 * Get the cache size
+	 *
+	 * @return integer Cache size in bytes.
+	 */
+	public static function get_stats(): int;
 }

--- a/inc/class-cachify-db.php
+++ b/inc/class-cachify-db.php
@@ -138,7 +138,7 @@ final class Cachify_DB implements Cachify_Backend {
 	/**
 	 * Get the cache size
 	 *
-	 * @return int Column size
+	 * @return integer Cache size in bytes.
 	 *
 	 * @since 2.0
 	 */

--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -142,12 +142,12 @@ final class Cachify_HDD implements Cachify_Backend {
 	/**
 	 * Get the cache size
 	 *
-	 * @return int Directory size
+	 * @return integer Cache size in bytes.
 	 *
 	 * @since 2.0
 	 */
 	public static function get_stats(): int {
-		return self::_dir_size( CACHIFY_CACHE_DIR );
+		return (int) self::_dir_size( CACHIFY_CACHE_DIR );
 	}
 
 	/**

--- a/inc/class-cachify-memcached.php
+++ b/inc/class-cachify-memcached.php
@@ -154,14 +154,14 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	/**
 	 * Get the cache size
 	 *
-	 * @return mixed Cache size
+	 * @return integer Cache size in bytes.
 	 *
 	 * @since 2.0.7
 	 */
-	public static function get_stats() {
+	public static function get_stats(): int {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
-			return null;
+			return 0;
 		}
 
 		/* Info */
@@ -169,7 +169,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 
 		/* No stats? */
 		if ( empty( $data ) ) {
-			return null;
+			return 0;
 		}
 
 		/* Get first key */
@@ -177,10 +177,10 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 
 		/* Empty */
 		if ( empty( $data['bytes'] ) ) {
-			return null;
+			return 0;
 		}
 
-		return $data['bytes'];
+		return (int) $data['bytes'];
 	}
 
 	/**

--- a/inc/class-cachify-noop.php
+++ b/inc/class-cachify-noop.php
@@ -104,7 +104,7 @@ final class Cachify_NOOP implements Cachify_Backend {
 	/**
 	 * Get the cache size
 	 *
-	 * @return int Column size
+	 * @return integer Cache size in bytes.
 	 */
 	public static function get_stats(): int {
 		return 0;

--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -133,12 +133,12 @@ final class Cachify_REDIS implements Cachify_Backend {
 	/**
 	 * Get the cache size
 	 *
-	 * @return integer Directory size
+	 * @return integer Cache size in bytes.
 	 */
-	public static function get_stats(): ?int {
+	public static function get_stats(): int {
 		/* Server connect */
 		if ( ! self::_connect_server() ) {
-			return null;
+			return 0;
 		}
 
 		/* Info */
@@ -146,15 +146,15 @@ final class Cachify_REDIS implements Cachify_Backend {
 
 		/* No stats? */
 		if ( empty( $data ) ) {
-			return null;
+			return 0;
 		}
 
 		/* Empty */
 		if ( empty( $data['used_memory_dataset'] ) ) {
-			return null;
+			return 0;
 		}
 
-		return $data['used_memory_dataset'];
+		return (int) $data['used_memory_dataset'];
 	}
 
 	/**

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -25,7 +25,7 @@ final class Cachify {
 	/**
 	 * Caching method
 	 *
-	 * @var object
+	 * @var Cachify_Backend
 	 *
 	 * @since 2.0
 	 */
@@ -602,12 +602,7 @@ final class Cachify {
 		$size = self::get_cache_size();
 
 		/* Caching method */
-		$method = call_user_func(
-			array(
-				self::$method,
-				'stringify_method',
-			)
-		);
+		$method = self::$method::stringify_method();
 
 		/* Output of the cache size */
 		$cachesize = ( 0 === $size )
@@ -655,12 +650,7 @@ final class Cachify {
 		$size = get_transient( 'cachify_cache_size' );
 		if ( ! $size ) {
 			/* Read */
-			$size = (int) call_user_func(
-				array(
-					self::$method,
-					'get_stats',
-				)
-			);
+			$size = self::$method::get_stats();
 
 			/* Save */
 			set_transient(
@@ -1209,7 +1199,7 @@ final class Cachify {
 		}
 
 		$hash = self::_cache_hash( $url );
-		call_user_func( array( self::$method, 'delete_item' ), $hash, $url );
+		self::$method::delete_item( $hash, $url );
 
 		/**
 		 * Call hook for further actions after cache has been flushed for a single page.
@@ -1543,7 +1533,7 @@ final class Cachify {
 			/* MEMCACHED */
 			Cachify_MEMCACHED::clear_cache();
 		} else {
-			call_user_func( array( self::$method, 'clear_cache' ) );
+			self::$method::clear_cache();
 		}
 
 		/**
@@ -1609,11 +1599,7 @@ final class Cachify {
 			 */
 			$data = apply_filters( 'cachify_modify_output', $data, self::$method, self::_cache_hash(), self::_cache_expires() );
 
-			call_user_func(
-				array(
-					self::$method,
-					'store_item',
-				),
+			self::$method::store_item(
 				self::_cache_hash(),
 				self::_minify_cache( $data ),
 				self::_cache_expires(),
@@ -1636,13 +1622,7 @@ final class Cachify {
 		}
 
 		/* Data present in cache */
-		$cache = call_user_func(
-			array(
-				self::$method,
-				'get_item',
-			),
-			self::_cache_hash()
-		);
+		$cache = self::$method::get_item( self::_cache_hash() );
 
 		/* No cache? */
 		if ( empty( $cache ) ) {
@@ -1651,14 +1631,7 @@ final class Cachify {
 		}
 
 		/* Process cache */
-		call_user_func(
-			array(
-				self::$method,
-				'print_cache',
-			),
-			self::_signature_details(),
-			$cache
-		);
+		self::$method::print_cache( self::_signature_details(), $cache );
 	}
 
 	/**


### PR DESCRIPTION
We expect all backend methods to implement certain logic. Now we have an interface `Cachify_Backend` to enforce this. Eliminate the use of `call_user_func()` and call backend methods directly.