### PR TITLE
refactor: remove underscores from private methods and vars

### DIFF
--- a/inc/class-cachify-db.php
+++ b/inc/class-cachify-db.php
@@ -59,9 +59,9 @@ final class Cachify_DB implements Cachify_Backend {
 			array(
 				'data' => $data,
 				'meta' => array(
-					'queries' => self::_page_queries(),
-					'timer'   => self::_page_timer(),
-					'memory'  => self::_page_memory(),
+					'queries' => self::page_queries(),
+					'timer'   => self::page_timer(),
+					'memory'  => self::page_memory(),
 					'time'    => current_time( 'timestamp' ),
 				),
 			),
@@ -128,7 +128,7 @@ final class Cachify_DB implements Cachify_Backend {
 		/* Signature - might contain runtime information, so it's generated at this point */
 		if ( isset( $cache['meta'] ) ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo self::_cache_signature( $sig_detail, $cache['meta'] );
+			echo self::cache_signature( $sig_detail, $cache['meta'] );
 		}
 
 		/* Quit */
@@ -165,7 +165,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 * @since 2.0
 	 * @since 2.3.0 added $detail parameter
 	 */
-	private static function _cache_signature( bool $detail, $meta ): string {
+	private static function cache_signature( bool $detail, $meta ): string {
 		/* No array? */
 		if ( ! is_array( $meta ) ) {
 			return '';
@@ -188,9 +188,9 @@ final class Cachify_DB implements Cachify_Backend {
 				),
 				sprintf(
 					'With Cachify: %d DB queries, %s seconds, %s',
-					self::_page_queries(),
-					self::_page_timer(),
-					self::_page_memory()
+					self::page_queries(),
+					self::page_timer(),
+					self::page_memory()
 				)
 			);
 		} else {
@@ -213,7 +213,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 0.1
 	 */
-	private static function _page_queries(): int {
+	private static function page_queries(): int {
 		return $GLOBALS['wpdb']->num_queries;
 	}
 
@@ -224,7 +224,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 0.1
 	 */
-	private static function _page_timer(): string {
+	private static function page_timer(): string {
 		return timer_stop( 0, 2 );
 	}
 
@@ -235,7 +235,7 @@ final class Cachify_DB implements Cachify_Backend {
 	 *
 	 * @since 0.7
 	 */
-	private static function _page_memory(): string {
+	private static function page_memory(): string {
 		return ( function_exists( 'memory_get_usage' ) ? size_format( memory_get_usage(), 2 ) : 0 );
 	}
 }

--- a/inc/class-cachify-hdd.php
+++ b/inc/class-cachify-hdd.php
@@ -76,8 +76,8 @@ final class Cachify_HDD implements Cachify_Backend {
 		}
 
 		/* Store data */
-		self::_create_files(
-			$data . self::_cache_signature( $sig_detail )
+		self::create_files(
+			$data . self::cache_signature( $sig_detail )
 		);
 	}
 
@@ -91,7 +91,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 */
 	public static function get_item( string $hash ) {
 		return is_readable(
-			self::_file_html()
+			self::file_html()
 		);
 	}
 
@@ -104,8 +104,8 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.0
 	 */
 	public static function delete_item( string $hash, string $url ): void {
-		self::_clear_dir(
-			self::_file_path( $url )
+		self::clear_dir(
+			self::file_path( $url )
 		);
 	}
 
@@ -115,7 +115,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.0
 	 */
 	public static function clear_cache(): void {
-		self::_clear_dir(
+		self::clear_dir(
 			CACHIFY_CACHE_DIR,
 			true
 		);
@@ -130,7 +130,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.0
 	 */
 	public static function print_cache( bool $sig_detail, $cache ): void {
-		$filename = self::_file_html();
+		$filename = self::file_html();
 		$size     = is_readable( $filename ) ? readfile( $filename ) : false;
 
 		if ( ! empty( $size ) ) {
@@ -147,7 +147,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.0
 	 */
 	public static function get_stats(): int {
-		return (int) self::_dir_size( CACHIFY_CACHE_DIR );
+		return (int) self::dir_size( CACHIFY_CACHE_DIR );
 	}
 
 	/**
@@ -160,7 +160,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 * @since 2.0
 	 * @since 2.3.0 added $detail parameter
 	 */
-	private static function _cache_signature( bool $detail ): string {
+	private static function cache_signature( bool $detail ): string {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | https://cachify.pluginkollektiv.org',
@@ -179,8 +179,8 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _create_files( string $data ): void {
-		$file_path = self::_file_path();
+	private static function create_files( string $data ): void {
+		$file_path = self::file_path();
 
 		/* Create directory */
 		if ( ! wp_mkdir_p( $file_path ) ) {
@@ -188,7 +188,7 @@ final class Cachify_HDD implements Cachify_Backend {
 			return;
 		}
 		/* Write to file */
-		self::_create_file( self::_file_html( $file_path ), $data );
+		self::create_file( self::file_html( $file_path ), $data );
 
 		/**
 		 * Filter that allows to enable/disable gzip file creation
@@ -196,7 +196,7 @@ final class Cachify_HDD implements Cachify_Backend {
 		 * @param bool $create_gzip_files Whether to create gzip files. Default is `true`
 		 */
 		if ( self::is_gzip_enabled() ) {
-			self::_create_file( self::_file_gzip( $file_path ), gzencode( $data, 9 ) );
+			self::create_file( self::file_gzip( $file_path ), gzencode( $data, 9 ) );
 		}
 	}
 
@@ -208,7 +208,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _create_file( string $file, string $data ): void {
+	private static function create_file( string $file, string $data ): void {
 		/* Writable? */
 		$handle = @fopen( $file, 'wb' );
 		if ( ! $handle ) {
@@ -237,7 +237,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _clear_dir( string $dir, bool $recursive = false ): void {
+	private static function clear_dir( string $dir, bool $recursive = false ): void {
 		// Remove trailing slash.
 		$dir = untrailingslashit( $dir );
 
@@ -260,19 +260,19 @@ final class Cachify_HDD implements Cachify_Backend {
 			if ( is_dir( $object ) ) {
 				if ( $recursive ) {
 					// Recursively clear the directory.
-					self::_clear_dir( $object, $recursive );
-				} elseif ( self::_user_can_delete( $object ) && 0 === count( glob( trailingslashit( $object ) . '*' ) ) ) {
+					self::clear_dir( $object, $recursive );
+				} elseif ( self::user_can_delete( $object ) && 0 === count( glob( trailingslashit( $object ) . '*' ) ) ) {
 					// Delete the directory, if empty.
 					@rmdir( $object );
 				}
-			} elseif ( self::_user_can_delete( $object ) ) {
+			} elseif ( self::user_can_delete( $object ) ) {
 				// Delete the file.
 				unlink( $object );
 			}
 		}
 
 		// Remove directory, if empty.
-		if ( self::_user_can_delete( $dir ) && 0 === count( glob( trailingslashit( $dir ) . '*' ) ) ) {
+		if ( self::user_can_delete( $dir ) && 0 === count( glob( trailingslashit( $dir ) . '*' ) ) ) {
 			@rmdir( $dir );
 		}
 
@@ -289,7 +289,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	public static function _dir_size( string $dir = '.' ) {
+	private static function dir_size( string $dir = '.' ) {
 		/* Is directory? */
 		if ( ! is_dir( $dir ) ) {
 			return false;
@@ -316,7 +316,7 @@ final class Cachify_HDD implements Cachify_Backend {
 
 			/* Directory or file */
 			if ( is_dir( $object ) ) {
-				$size += self::_dir_size( $object );
+				$size += self::dir_size( $object );
 			} else {
 				$size += filesize( $object );
 			}
@@ -334,7 +334,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _file_path( ?string $path = null ): string {
+	private static function file_path( ?string $path = null ): string {
 		$prefix = is_ssl() ? 'https-' : '';
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
@@ -366,8 +366,8 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _file_html( string $file_path = '' ): string {
-		return ( empty( $file_path ) ? self::_file_path() : $file_path ) . 'index.html';
+	private static function file_html( string $file_path = '' ): string {
+		return ( empty( $file_path ) ? self::file_path() : $file_path ) . 'index.html';
 	}
 
 	/**
@@ -379,8 +379,8 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @since 2.0
 	 */
-	private static function _file_gzip( string $file_path = '' ): string {
-		return ( empty( $file_path ) ? self::_file_path() : $file_path ) . 'index.html.gz';
+	private static function file_gzip( string $file_path = '' ): string {
+		return ( empty( $file_path ) ? self::file_path() : $file_path ) . 'index.html.gz';
 	}
 
 	/**
@@ -390,7 +390,7 @@ final class Cachify_HDD implements Cachify_Backend {
 	 *
 	 * @return bool
 	 */
-	private static function _user_can_delete( string $file ): bool {
+	private static function user_can_delete( string $file ): bool {
 		if ( ! is_file( $file ) && ! is_dir( $file ) ) {
 			return false;
 		}

--- a/inc/class-cachify-memcached.php
+++ b/inc/class-cachify-memcached.php
@@ -22,7 +22,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	private static $_memcached = null;
+	private static $memcached = null;
 
 	/**
 	 * Availability check
@@ -67,14 +67,14 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 		}
 
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return;
 		}
 
 		/* Add item */
-		self::$_memcached->set(
-			self::_file_path(),
-			$data . self::_cache_signature( $sig_detail ),
+		self::$memcached->set(
+			self::file_path(),
+			$data . self::cache_signature( $sig_detail ),
 			$lifetime
 		);
 	}
@@ -90,13 +90,13 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 */
 	public static function get_item( string $hash ) {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return null;
 		}
 
 		/* Get item */
-		return self::$_memcached->get(
-			self::_file_path()
+		return self::$memcached->get(
+			self::file_path()
 		);
 	}
 
@@ -110,13 +110,13 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 */
 	public static function delete_item( string $hash, string $url = '' ): void {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return;
 		}
 
 		/* Delete */
-		self::$_memcached->delete(
-			self::_file_path( $url )
+		self::$memcached->delete(
+			self::file_path( $url )
 		);
 	}
 
@@ -127,16 +127,16 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 */
 	public static function clear_cache(): void {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return;
 		}
 
-		if ( ! self::$_memcached instanceof Memcached ) {
+		if ( ! self::$memcached instanceof Memcached ) {
 			return;
 		}
 
 		/* Flush */
-		self::$_memcached->flush();
+		self::$memcached->flush();
 	}
 
 	/**
@@ -160,12 +160,12 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 */
 	public static function get_stats(): int {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return 0;
 		}
 
 		/* Info */
-		$data = self::$_memcached->getStats();
+		$data = self::$memcached->getStats();
 
 		/* No stats? */
 		if ( empty( $data ) ) {
@@ -193,7 +193,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 * @since 2.0.7
 	 * @since 2.3.0 added $detail parameter
 	 */
-	private static function _cache_signature( bool $detail ): string {
+	private static function cache_signature( bool $detail ): string {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | https://cachify.pluginkollektiv.org',
@@ -214,7 +214,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	private static function _file_path( ?string $path = null ): string {
+	private static function file_path( ?string $path = null ): string {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$path_parts = wp_parse_url( $path ? $path : wp_unslash( $_SERVER['REQUEST_URI'] ) );
 
@@ -237,27 +237,27 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 	 *
 	 * @since 2.0.7
 	 */
-	private static function _connect_server(): bool {
+	private static function connect_server(): bool {
 		/* Not enabled? */
 		if ( ! self::is_available() ) {
 			return false;
 		}
 
 		/* Already connected */
-		if ( ! is_null( self::$_memcached ) ) {
+		if ( ! is_null( self::$memcached ) ) {
 			return true;
 		}
 
 		/* Init */
-		self::$_memcached = new Memcached();
+		self::$memcached = new Memcached();
 
 		/* Set options */
 		if ( defined( 'HHVM_VERSION' ) ) {
-			self::$_memcached->setOption( Memcached::OPT_COMPRESSION, false );
-			self::$_memcached->setOption( Memcached::OPT_BUFFER_WRITES, true );
-			self::$_memcached->setOption( Memcached::OPT_BINARY_PROTOCOL, true );
+			self::$memcached->setOption( Memcached::OPT_COMPRESSION, false );
+			self::$memcached->setOption( Memcached::OPT_BUFFER_WRITES, true );
+			self::$memcached->setOption( Memcached::OPT_BINARY_PROTOCOL, true );
 		} else {
-			self::$_memcached->setOptions(
+			self::$memcached->setOptions(
 				array(
 					Memcached::OPT_COMPRESSION     => false,
 					Memcached::OPT_BUFFER_WRITES   => true,
@@ -267,7 +267,7 @@ final class Cachify_MEMCACHED implements Cachify_Backend {
 		}
 
 		/* Connect */
-		self::$_memcached->addServers(
+		self::$memcached->addServers(
 			(array) apply_filters(
 				'cachify_memcached_servers',
 				array(

--- a/inc/class-cachify-redis.php
+++ b/inc/class-cachify-redis.php
@@ -20,7 +20,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 *
 	 * @var Redis|null
 	 */
-	private static $_redis;
+	private static $redis;
 
 	/**
 	 * Availability check
@@ -56,14 +56,14 @@ final class Cachify_REDIS implements Cachify_Backend {
 		}
 
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return;
 		}
 
 		/* Add item */
-		self::$_redis->set(
-			self::_file_path(),
-			$data . self::_cache_signature( $sig_detail ),
+		self::$redis->set(
+			self::file_path(),
+			$data . self::cache_signature( $sig_detail ),
 			$lifetime
 		);
 	}
@@ -76,13 +76,13 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 */
 	public static function get_item( string $hash ) {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return null;
 		}
 
 		/* Get item */
-		return self::$_redis->get(
-			self::_file_path()
+		return self::$redis->get(
+			self::file_path()
 		);
 	}
 
@@ -94,13 +94,13 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 */
 	public static function delete_item( string $hash, string $url ): void {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return;
 		}
 
 		/* Delete */
-		self::$_redis->del(
-			self::_file_path( $url )
+		self::$redis->del(
+			self::file_path( $url )
 		);
 	}
 
@@ -111,12 +111,12 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 */
 	public static function clear_cache(): void {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return;
 		}
 
 		/* Flush */
-		@self::$_redis->flushAll();
+		@self::$redis->flushAll();
 	}
 
 	/**
@@ -137,12 +137,12 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 */
 	public static function get_stats(): int {
 		/* Server connect */
-		if ( ! self::_connect_server() ) {
+		if ( ! self::connect_server() ) {
 			return 0;
 		}
 
 		/* Info */
-		$data = self::$_redis->info( 'MEMORY' );
+		$data = self::$redis->info( 'MEMORY' );
 
 		/* No stats? */
 		if ( empty( $data ) ) {
@@ -163,7 +163,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 * @param bool $detail Show details in signature.
 	 * @return string Signature string
 	 */
-	private static function _cache_signature( bool $detail ): string {
+	private static function cache_signature( bool $detail ): string {
 		return sprintf(
 			"\n\n<!-- %s\n%s @ %s -->",
 			'Cachify | https://cachify.pluginkollektiv.org',
@@ -181,7 +181,7 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 * @param string|null $path Request URI or permalink [optional].
 	 * @return string Path to cache file
 	 */
-	private static function _file_path( ?string $path = null ): string {
+	private static function file_path( ?string $path = null ): string {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$path_parts = wp_parse_url( $path ? $path : wp_unslash( $_SERVER['REQUEST_URI'] ) );
 
@@ -200,19 +200,19 @@ final class Cachify_REDIS implements Cachify_Backend {
 	 *
 	 * @return boolean TRUE on success
 	 */
-	private static function _connect_server(): bool {
+	private static function connect_server(): bool {
 		/* Not enabled? */
 		if ( ! self::is_available() ) {
 			return false;
 		}
 
 		/* Have object and it thinks it's connected to a server */
-		if ( is_object( self::$_redis ) && self::$_redis->isConnected() ) {
+		if ( is_object( self::$redis ) && self::$redis->isConnected() ) {
 			return true;
 		}
 
 		/* Init */
-		self::$_redis = new Redis();
+		self::$redis = new Redis();
 
 		/**
 		 * Filter hook to adjust Redis connection parameters
@@ -232,9 +232,9 @@ final class Cachify_REDIS implements Cachify_Backend {
 
 		// Establish connection.
 		try {
-			self::$_redis->connect( ...$con );
+			self::$redis->connect( ...$con );
 
-			if ( ! self::$_redis->isConnected() ) {
+			if ( ! self::$redis->isConnected() ) {
 				return false;
 			}
 		} catch ( Exception $e ) {

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -90,7 +90,7 @@ final class Cachify {
 	 */
 	public static function init(): void {
 		/* Set defaults */
-		self::_set_default_vars();
+		self::set_default_vars();
 
 		self::$is_nginx = $GLOBALS['is_nginx'];
 
@@ -192,19 +192,19 @@ final class Cachify {
 		/* Multisite & Network */
 		if ( is_multisite() && ! empty( $_GET['networkwide'] ) ) {
 			/* Blog IDs */
-			$ids = self::_get_blog_ids();
+			$ids = self::get_blog_ids();
 
 			/* Loop over blogs */
 			foreach ( $ids as $id ) {
 				switch_to_blog( $id );
-				self::_install_backend();
+				self::install_backend();
 			}
 
 			/* Switch back */
 			restore_current_blog();
 
 		} else {
-			self::_install_backend();
+			self::install_backend();
 		}
 	}
 
@@ -227,7 +227,7 @@ final class Cachify {
 		switch_to_blog( (int) $new_site->blog_id );
 
 		/* Install */
-		self::_install_backend();
+		self::install_backend();
 
 		/* Switch back */
 		restore_current_blog();
@@ -238,7 +238,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	private static function _install_backend(): void {
+	private static function install_backend(): void {
 		add_option(
 			'cachify',
 			array()
@@ -263,18 +263,18 @@ final class Cachify {
 			$old = $wpdb->blogid;
 
 			/* Blog IDs */
-			$ids = self::_get_blog_ids();
+			$ids = self::get_blog_ids();
 
 			/* Loop */
 			foreach ( $ids as $id ) {
 				switch_to_blog( $id );
-				self::_uninstall_backend();
+				self::uninstall_backend();
 			}
 
 			/* Switch back */
 			switch_to_blog( $old );
 		} else {
-			self::_uninstall_backend();
+			self::uninstall_backend();
 		}
 	}
 
@@ -297,7 +297,7 @@ final class Cachify {
 		switch_to_blog( (int) $old_site->blog_id );
 
 		/* Install */
-		self::_uninstall_backend();
+		self::uninstall_backend();
 
 		/* Switch back */
 		restore_current_blog();
@@ -308,7 +308,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	private static function _uninstall_backend(): void {
+	private static function uninstall_backend(): void {
 		/* Option */
 		delete_option( 'cachify' );
 
@@ -323,7 +323,7 @@ final class Cachify {
 	 *
 	 * @since 1.0
 	 */
-	private static function _get_blog_ids(): array {
+	private static function get_blog_ids(): array {
 		/* Global */
 		global $wpdb;
 
@@ -383,9 +383,9 @@ final class Cachify {
 	 *
 	 * @since 2.0
 	 */
-	private static function _set_default_vars(): void {
+	private static function set_default_vars(): void {
 		/* Options */
-		self::$options = self::_get_options();
+		self::$options = self::get_options();
 
 		if ( self::METHOD_APC === self::$options['use_apc'] ) {
 			/* APC */
@@ -462,7 +462,7 @@ final class Cachify {
 	 *
 	 * @since 2.0
 	 */
-	private static function _get_options(): array {
+	private static function get_options(): array {
 		return wp_parse_args(
 			get_option( 'cachify' ),
 			array(
@@ -850,7 +850,7 @@ final class Cachify {
 			$old = $GLOBALS['wpdb']->blogid;
 
 			/* Blog IDs */
-			$ids = self::_get_blog_ids();
+			$ids = self::get_blog_ids();
 
 			/* Loop over blogs */
 			foreach ( $ids as $id ) {
@@ -1198,7 +1198,7 @@ final class Cachify {
 			return;
 		}
 
-		$hash = self::_cache_hash( $url );
+		$hash = self::cache_hash( $url );
 		self::$method::delete_item( $hash, $url );
 
 		/**
@@ -1219,7 +1219,7 @@ final class Cachify {
 	 *
 	 * @since 2.0.0
 	 */
-	private static function _cache_expires(): int {
+	private static function cache_expires(): int {
 		return HOUR_IN_SECONDS * self::$options['cache_expires'];
 	}
 
@@ -1230,7 +1230,7 @@ final class Cachify {
 	 *
 	 * @since 2.3.0
 	 */
-	private static function _signature_details(): bool {
+	private static function signature_details(): bool {
 		return 1 === self::$options['sig_detail'];
 	}
 
@@ -1244,7 +1244,7 @@ final class Cachify {
 	 * @since 0.1
 	 * @since 2.0
 	 */
-	private static function _cache_hash( string $url = '' ): string {
+	private static function cache_hash( string $url = '' ): string {
 		$prefix = is_ssl() ? 'https-' : '';
 
 		if ( empty( $url ) ) {
@@ -1268,7 +1268,7 @@ final class Cachify {
 	 * @since 0.9.1
 	 * @since 1.0
 	 */
-	private static function _preg_split( string $input ): array {
+	private static function preg_split( string $input ): array {
 		return (array) preg_split( '/,/', $input, -1, PREG_SPLIT_NO_EMPTY );
 	}
 
@@ -1279,7 +1279,7 @@ final class Cachify {
 	 *
 	 * @since 0.6
 	 */
-	private static function _is_index(): bool {
+	private static function is_index(): bool {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		return basename( wp_unslash( $_SERVER['SCRIPT_NAME'] ) ) === 'index.php';
 	}
@@ -1291,7 +1291,7 @@ final class Cachify {
 	 *
 	 * @since 0.9.1
 	 */
-	private static function _is_mobile(): bool {
+	private static function is_mobile(): bool {
 		$templatedir = get_template_directory();
 		return ( strpos( $templatedir, 'wptouch' ) || strpos( $templatedir, 'carrington' ) || strpos( $templatedir, 'jetpack' ) || strpos( $templatedir, 'handheld' ) );
 	}
@@ -1303,7 +1303,7 @@ final class Cachify {
 	 *
 	 * @since 2.0.0
 	 */
-	private static function _is_logged_in(): bool {
+	private static function is_logged_in(): bool {
 		/* Logged in */
 		if ( is_user_logged_in() ) {
 			return true;
@@ -1364,7 +1364,7 @@ final class Cachify {
 	 *
 	 * @since 0.2
 	 */
-	private static function _skip_cache(): bool {
+	private static function skip_cache(): bool {
 
 		/* Plugin options */
 		$options = self::$options;
@@ -1378,12 +1378,12 @@ final class Cachify {
 		}
 
 		/* Only cache requests routed through main index.php (skip AJAX, WP-Cron, WP-CLI etc.) */
-		if ( ! self::_is_index() ) {
+		if ( ! self::is_index() ) {
 			return true;
 		}
 
 		/* Logged in */
-		if ( $options['only_guests'] && self::_is_logged_in() ) {
+		if ( $options['only_guests'] && self::is_logged_in() ) {
 			return true;
 		}
 
@@ -1403,13 +1403,13 @@ final class Cachify {
 		}
 
 		/* Mobile request */
-		if ( self::_is_mobile() ) {
+		if ( self::is_mobile() ) {
 			return true;
 		}
 
 		/* Post IDs */
 		if ( $options['without_ids'] && is_singular() ) {
-			$without_ids = array_map( 'intval', self::_preg_split( $options['without_ids'] ) );
+			$without_ids = array_map( 'intval', self::preg_split( $options['without_ids'] ) );
 			if ( in_array( $GLOBALS['wp_query']->get_queried_object_id(), $without_ids, true ) ) {
 				return true;
 			}
@@ -1417,7 +1417,7 @@ final class Cachify {
 
 		/* User Agents */
 		if ( $options['without_agents'] && isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			$user_agent_strings = self::_preg_split( $options['without_agents'] );
+			$user_agent_strings = self::preg_split( $options['without_agents'] );
 			foreach ( $user_agent_strings as $user_agent_string ) {
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				if ( strpos( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ), $user_agent_string ) !== false ) {
@@ -1452,7 +1452,7 @@ final class Cachify {
 	 *
 	 * @since 0.9.2
 	 */
-	private static function _minify_cache( string $data ): string {
+	private static function minify_cache( string $data ): string {
 		/* Disabled? */
 		if ( ! self::$options['compress_html'] ) {
 			return $data;
@@ -1581,8 +1581,8 @@ final class Cachify {
 			200 === http_response_code(),
 			$data,
 			self::$method,
-			self::_cache_hash(),
-			self::_cache_expires()
+			self::cache_hash(),
+			self::cache_expires()
 		);
 
 		/* Save? */
@@ -1597,13 +1597,13 @@ final class Cachify {
 			 *
 			 * @since 2.4.0
 			 */
-			$data = apply_filters( 'cachify_modify_output', $data, self::$method, self::_cache_hash(), self::_cache_expires() );
+			$data = apply_filters( 'cachify_modify_output', $data, self::$method, self::cache_hash(), self::cache_expires() );
 
 			self::$method::store_item(
-				self::_cache_hash(),
-				self::_minify_cache( $data ),
-				self::_cache_expires(),
-				self::_signature_details()
+				self::cache_hash(),
+				self::minify_cache( $data ),
+				self::cache_expires(),
+				self::signature_details()
 			);
 		}
 
@@ -1617,12 +1617,12 @@ final class Cachify {
 	 */
 	public static function manage_cache(): void {
 		/* No caching? */
-		if ( self::_skip_cache() ) {
+		if ( self::skip_cache() ) {
 			return;
 		}
 
 		/* Data present in cache */
-		$cache = self::$method::get_item( self::_cache_hash() );
+		$cache = self::$method::get_item( self::cache_hash() );
 
 		/* No cache? */
 		if ( empty( $cache ) ) {
@@ -1631,7 +1631,7 @@ final class Cachify {
 		}
 
 		/* Process cache */
-		self::$method::print_cache( self::_signature_details(), $cache );
+		self::$method::print_cache( self::signature_details(), $cache );
 	}
 
 	/**
@@ -1769,8 +1769,8 @@ final class Cachify {
 	 * @since 1.0
 	 */
 	public static function options_page(): void {
-		$options      = self::_get_options();
-		$cachify_tabs = self::_get_tabs( $options );
+		$options      = self::get_options();
+		$cachify_tabs = self::get_tabs( $options );
 		$current_tab  = isset( $_GET['cachify_tab'] ) && isset( $cachify_tabs[ $_GET['cachify_tab'] ] )
 			? sanitize_text_field( wp_unslash( $_GET['cachify_tab'] ) )
 			: 'settings';
@@ -1821,7 +1821,7 @@ final class Cachify {
 	 *
 	 * @since 2.3.0
 	 */
-	private static function _get_tabs( array $options ): array {
+	private static function get_tabs( array $options ): array {
 		/* Settings tab is always present */
 		$tabs = array(
 			'settings' => array(

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -22,13 +22,13 @@
     <!-- WordPress coding standards -->
     <config name="minimum_supported_wp_version" value="5.1"/>
     <rule ref="WordPress">
-        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
-        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
         <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
     </rule>
     <rule ref="WordPress.WP.I18n">
         <properties>
-            <property name="text_domain" type="array" value="cachify"/>
+            <property name="text_domain" type="array">
+                <element value="cachify"/>
+            </property>
         </properties>
     </rule>
 


### PR DESCRIPTION
Remove the code style exclusion for underscore-prefixed private methods and fields and rename all occurrences without functional change.

Also make `Cachify_HDD::_dir_size()` private, because it is not used anywhere else and not really designed for public usage as the prefixed name indicates.