### PR TITLE
Fix: wrap add_query_arg() and plugins_url() with esc_url() in admin link and SVG href contexts

### DIFF
--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -447,7 +447,7 @@ final class Cachify {
 					sprintf(
 						/* translators: Link to Cachify settings page inserted at placeholder */
 						__( 'Please check your server configuration and visit the <a href="%s">settings page</a> to chose a different method.', 'cachify' ),
-						add_query_arg( array( 'page' => 'cachify' ), admin_url( 'options-general.php' ) )
+						esc_url( add_query_arg( array( 'page' => 'cachify' ), admin_url( 'options-general.php' ) ) )
 					),
 					array( 'a' => array( 'href' => array() ) )
 				)
@@ -546,12 +546,12 @@ final class Cachify {
 			array(
 				sprintf(
 					'<a href="%s">%s</a>',
-					add_query_arg(
+					esc_url( add_query_arg(
 						array(
 							'page' => 'cachify',
 						),
 						admin_url( 'options-general.php' )
-					),
+					) ),
 					esc_html__( 'Settings', 'cachify' )
 				),
 			)
@@ -616,12 +616,12 @@ final class Cachify {
             <svg class="cachify-icon cachify-icon--%s" aria-hidden="true" role="img">
                 <use href="%s#cachify-icon-%s" xlink:href="%s#cachify-icon-%s" />
             </svg> %s</a>',
-			add_query_arg(
+			esc_url( add_query_arg(
 				array(
 					'page' => 'cachify',
 				),
 				admin_url( 'options-general.php' )
-			),
+			) ),
 			sprintf(
 				/* translators: 1: "Caching method label"; 2: Actual method. */
 				esc_html__( '%1$s: %2$s', 'cachify' ),
@@ -629,9 +629,9 @@ final class Cachify {
 				esc_attr( strtolower( $method ) )
 			),
 			esc_attr( $method ),
-			plugins_url( 'images/symbols.svg', CACHIFY_FILE ),
+			esc_url( plugins_url( 'images/symbols.svg', CACHIFY_FILE ) ),
 			esc_attr( strtolower( $method ) ),
-			plugins_url( 'images/symbols.svg', CACHIFY_FILE ),
+			esc_url( plugins_url( 'images/symbols.svg', CACHIFY_FILE ) ),
 			esc_attr( strtolower( $method ) ),
 			$cachesize
 		);

--- a/inc/class-cachify.php
+++ b/inc/class-cachify.php
@@ -546,12 +546,12 @@ final class Cachify {
 			array(
 				sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( add_query_arg(
-						array(
-							'page' => 'cachify',
-						),
-						admin_url( 'options-general.php' )
-					) ),
+					esc_url(
+						add_query_arg(
+							array( 'page' => 'cachify' ),
+							admin_url( 'options-general.php' )
+						)
+					),
 					esc_html__( 'Settings', 'cachify' )
 				),
 			)
@@ -616,12 +616,12 @@ final class Cachify {
             <svg class="cachify-icon cachify-icon--%s" aria-hidden="true" role="img">
                 <use href="%s#cachify-icon-%s" xlink:href="%s#cachify-icon-%s" />
             </svg> %s</a>',
-			esc_url( add_query_arg(
-				array(
-					'page' => 'cachify',
-				),
-				admin_url( 'options-general.php' )
-			) ),
+			esc_url(
+				add_query_arg(
+					array( 'page' => 'cachify' ),
+					admin_url( 'options-general.php' )
+				)
+			),
 			sprintf(
 				/* translators: 1: "Caching method label"; 2: Actual method. */
 				esc_html__( '%1$s: %2$s', 'cachify' ),


### PR DESCRIPTION
## What & Why

Five places in `class-cachify.php` output URLs in HTML `href` or `xlink:href` context without `esc_url()`:

- Admin notice settings link (`wp_kses`/`sprintf`)
- Dashboard plugin-meta settings link (`sprintf`)
- At-a-glance widget admin link (`sprintf`)
- Two SVG `<use href>` and `xlink:href` attributes (`plugins_url()`)

All five are flagged by the [WordPress Plugin Check](https://wordpress.org/plugins/plugin-check/) tool.

## The Fix

Wrap each with `esc_url()`. One-line change per site, consistent with how other URLs are handled elsewhere in the file.

## Verify the Fix

1. Activate Cachify on a WP install with an admin account.
2. Check the admin notice (if visible), the Plugins page meta links, and the Dashboard "At a Glance" widget — all links should render and navigate correctly.
3. Run [Plugin Check](https://wordpress.org/plugins/plugin-check/) — the five escaping notices no longer appear.

---
(full disclosure: AI helped me identify the issue and verify my work)